### PR TITLE
Add monospace font toggle to note toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Resize:** drag any edge/corner
 - **Color:** click the color dot in the hover bar to open a small palette
 - **Opacity / text size:** controls in the hover bar
+- **Code / monospace:** the `{}` icon in the hover bar switches that note to a monospace font (saved per note)
 - **Pin / unpin:** the 📌 icon in the hover bar. Pinned (default) keeps the note always-on-top, even when you switch to another app. Unpinned makes it a normal window that gets covered when another app is focused.
 - **Click-through mode:** the ghost icon (👻) in the hover bar — clicks pass through to whatever is behind the note; hover the bar to interact again
 - **Close a note:** ✕ in the hover bar — this **hides** the note, it does not delete it. The note stays in the Notes Manager and can be reopened any time.

--- a/main.js
+++ b/main.js
@@ -153,12 +153,13 @@ function reconcileOpenWindowsToDisplays() {
 // ---------- IPC from renderer ----------
 ipcMain.on('note:update', (e, payload) => {
   if (!payload || typeof payload.id !== 'string') return;
-  const { id, text, color, opacity, fontSize, ghost } = payload;
+  const { id, text, color, opacity, fontSize, monospace, ghost } = payload;
   const patch = {};
   if (typeof text === 'string') patch.text = text;
   if (typeof color === 'string') patch.color = color;
   if (typeof opacity === 'number') patch.opacity = opacity;
   if (typeof fontSize === 'number') patch.fontSize = fontSize;
+  if (typeof monospace === 'boolean') patch.monospace = monospace;
   if (typeof ghost === 'boolean') patch.ghost = ghost;
   const record = store.update(id, patch);
 

--- a/note.html
+++ b/note.html
@@ -63,6 +63,11 @@
   #pin.active { opacity: 1; background: rgba(0,0,0,0.12); }
   body.dark #pin.active { background: rgba(255,255,255,0.18); }
 
+  /* Monospace toggle: dim when off so the on-state matches pin. */
+  #mono { opacity: 0.4; font-family: ui-monospace, "SF Mono", Consolas, monospace; font-size: 13px; }
+  #mono.active { opacity: 1; background: rgba(0,0,0,0.12); }
+  body.dark #mono.active { background: rgba(255,255,255,0.18); }
+
   .color-control { position: relative; -webkit-app-region: no-drag; }
   .color-dot {
     display: block;
@@ -137,6 +142,9 @@
     user-select: text;
     font-family: inherit;
   }
+  .note.mono textarea {
+    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, "Cascadia Code", monospace;
+  }
   textarea::placeholder { color: rgba(0,0,0,0.35); }
 
   /* Dark theme readability */
@@ -160,6 +168,7 @@
       <div class="spacer"></div>
       <button class="btn" id="fontDown" title="Smaller text">A−</button>
       <button class="btn" id="fontUp" title="Larger text">A+</button>
+      <button class="btn" id="mono" title="Monospace: better for code snippets">{}</button>
       <button class="btn" id="pin" title="Pinned: stays on top when you switch apps">📌</button>
       <button class="btn" id="ghost" title="Click-through: see & click behind (⌘⇧G)">👻</button>
       <button class="btn" id="new" title="New note">＋</button>

--- a/note.html
+++ b/note.html
@@ -7,6 +7,7 @@
     --tint: 255, 224, 130;   /* default: yellow */
     --opacity: 0.85;
     --font-size: 15px;
+    --mono-font: ui-monospace, "SF Mono", "Fira Code", Consolas, "Cascadia Code", monospace;
   }
 
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -64,7 +65,7 @@
   body.dark #pin.active { background: rgba(255,255,255,0.18); }
 
   /* Monospace toggle: dim when off so the on-state matches pin. */
-  #mono { opacity: 0.4; font-family: ui-monospace, "SF Mono", Consolas, monospace; font-size: 13px; }
+  #mono { opacity: 0.4; font-family: var(--mono-font); font-size: 13px; }
   #mono.active { opacity: 1; background: rgba(0,0,0,0.12); }
   body.dark #mono.active { background: rgba(255,255,255,0.18); }
 
@@ -143,7 +144,7 @@
     font-family: inherit;
   }
   .note.mono textarea {
-    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, "Cascadia Code", monospace;
+    font-family: var(--mono-font);
   }
   textarea::placeholder { color: rgba(0,0,0,0.35); }
 

--- a/note.js
+++ b/note.js
@@ -18,8 +18,9 @@ const swatchesEl = document.getElementById('swatches');
 const colorBtn = document.getElementById('colorBtn');
 const colorPopover = document.getElementById('colorPopover');
 const pinBtn = document.getElementById('pin');
+const monoBtn = document.getElementById('mono');
 
-let state = { text: '', color: 'yellow', opacity: 0.85, fontSize: 15, ghost: false, pinned: true };
+let state = { text: '', color: 'yellow', opacity: 0.85, fontSize: 15, monospace: false, ghost: false, pinned: true };
 
 const noteEl = document.querySelector('.note');
 const barEl = document.querySelector('.bar');
@@ -81,6 +82,25 @@ function setPinned(on) {
 
 pinBtn.addEventListener('click', () => setPinned(!state.pinned));
 
+// --- Monospace (code snippet) toggle ---
+// Proportional system UI font is the default; {} switches the textarea to
+// a stacked monospace family so code walkthrough notes stay aligned.
+function applyMonospace() {
+  noteEl.classList.toggle('mono', state.monospace);
+  monoBtn.classList.toggle('active', state.monospace);
+  monoBtn.title = state.monospace
+    ? 'Monospace on: click to use the default font'
+    : 'Monospace: better for code snippets';
+}
+
+function setMonospace(on) {
+  state.monospace = on;
+  applyMonospace();
+  push();
+}
+
+monoBtn.addEventListener('click', () => setMonospace(!state.monospace));
+
 function applyColor(color) {
   const c = COLORS[color] || COLORS.yellow;
   root.style.setProperty('--tint', c.tint);
@@ -115,6 +135,7 @@ function applyState() {
   textEl.value = state.text;
   applyGhost();
   applyPinned();
+  applyMonospace();
 }
 
 function push() {
@@ -124,6 +145,7 @@ function push() {
     color: state.color,
     opacity: state.opacity,
     fontSize: state.fontSize,
+    monospace: state.monospace,
     ghost: state.ghost
   });
 }
@@ -176,6 +198,9 @@ window.notes.onToggleGhost(() => setGhost(!state.ghost));
 // Load persisted state
 window.notes.getState(id).then((s) => {
   if (s) state = Object.assign(state, s);
+  // Older records (pre-v4) may omit this; treat missing as off so
+  // classList.toggle(..., force) never gets undefined (which would flip).
+  state.monospace = !!state.monospace;
   applyState();
   textEl.focus();
 });

--- a/note.js
+++ b/note.js
@@ -198,8 +198,8 @@ window.notes.onToggleGhost(() => setGhost(!state.ghost));
 // Load persisted state
 window.notes.getState(id).then((s) => {
   if (s) state = Object.assign(state, s);
-  // Older records (pre-v4) may omit this; treat missing as off so
-  // classList.toggle(..., force) never gets undefined (which would flip).
+  // Older records (pre-v4) may omit this; normalize missing to false
+  // so the renderer always treats monospace as a boolean.
   state.monospace = !!state.monospace;
   applyState();
   textEl.focus();

--- a/store.js
+++ b/store.js
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const STORE_VERSION = 3;
+const STORE_VERSION = 4;
 
 function nextId() {
   return 'note-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
@@ -24,6 +24,8 @@ function defaultRecord(overrides = {}) {
     displayId: overrides.displayId ?? null,
     opacity: typeof overrides.opacity === 'number' ? overrides.opacity : 0.85,
     fontSize: overrides.fontSize || 15,
+    // Per-note monospace toggle for code walkthroughs (issue #7).
+    monospace: !!overrides.monospace,
     ghost: !!overrides.ghost,
     visible: overrides.visible !== undefined ? !!overrides.visible : true,
     // Pinned = always-on-top, survives switching focus to another app.
@@ -36,23 +38,35 @@ function defaultRecord(overrides = {}) {
 
 // v1 files were `{ notes: [...] }` with no `version` field and no `visible`/`title`.
 // v2 files have a version field but no `pinned`.
+// v3 files have pinned but no `monospace`.
 function migrate(data) {
   if (!data || typeof data !== 'object') return { version: STORE_VERSION, notes: [] };
   if (!Array.isArray(data.notes)) return { version: STORE_VERSION, notes: [] };
 
   if (!data.version) {
-    // v1 -> v3: add visible/title/displayId/pinned/timestamps, keep the rest.
+    // v1 -> current: add visible/title/displayId/pinned/monospace/timestamps.
     return {
       version: STORE_VERSION,
       notes: data.notes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }))
     };
   }
   if (data.version === 2) {
-    // v2 -> v3: backfill pinned:true so existing notes keep today's
-    // always-on-top behavior unchanged.
+    // v2 -> current: backfill pinned:true so existing notes keep today's
+    // always-on-top behavior unchanged, plus monospace:false.
     return {
       version: STORE_VERSION,
-      notes: data.notes.map((n) => ({ ...n, pinned: n.pinned !== undefined ? !!n.pinned : true }))
+      notes: data.notes.map((n) => ({
+        ...n,
+        pinned: n.pinned !== undefined ? !!n.pinned : true,
+        monospace: !!n.monospace
+      }))
+    };
+  }
+  if (data.version === 3) {
+    // v3 -> v4: existing notes stay proportional unless the user toggles {}.
+    return {
+      version: STORE_VERSION,
+      notes: data.notes.map((n) => ({ ...n, monospace: !!n.monospace }))
     };
   }
   return data;

--- a/store.js
+++ b/store.js
@@ -52,7 +52,8 @@ function migrate(data) {
   }
   if (data.version === 2) {
     // v2 -> current: backfill pinned:true so existing notes keep today's
-    // always-on-top behavior unchanged, plus monospace:false.
+    // always-on-top behavior unchanged. Monospace defaults to off unless
+    // the record already has it set.
     return {
       version: STORE_VERSION,
       notes: data.notes.map((n) => ({


### PR DESCRIPTION
## Description

Adds a `{}` toggle on each note's hover toolbar so the textarea can switch to a monospace font for code walkthroughs. The choice is saved per note and restored on launch.

## Related Issue

Closes #7

## Changes Made

- Add a `{}` button next to the font-size controls on the note hover bar
- Apply a stacked monospace family (`SF Mono`, Fira Code, Consolas, Cascadia Code) when the toggle is on
- Persist `monospace` on each note record (store v4 migration) and round-trip it through `note:update`

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (if applicable)

**Steps to reproduce / verify:**
1. Hover a note and click `{}` in the toolbar — the text should switch to monospace and the button should look active.
2. Type a few lines of code and confirm alignment looks right.
3. Quit and reopen Ghost Notes — that note should still be monospace.
4. Click `{}` again — it should return to the default proportional font.

Verified on macOS: toggle switches the textarea font, `notes.json` stores `monospace: true` (store v4), and the choice survives quit/reopen.

## Screenshots / Recordings (if applicable)

N/A — UI is a small toolbar button plus font change on the existing textarea. Ghost Notes is excluded from screen capture, so a recording would not show the note.

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `main`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`