### PR TITLE
Fix #10: Encrypt notes.json data at rest

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, ipcMain, screen, Tray, Menu, nativeImage, dialog, powerMonitor } = require('electron');
+const { app, ipcMain, screen, Tray, Menu, nativeImage, dialog, powerMonitor, safeStorage } = require('electron');
 const path = require('path');
 const { NoteStore } = require('./store');
 const platform = require('./platform');
@@ -9,22 +9,53 @@ const { createManagerModule } = require('./manager');
 
 // Show plain-language notices only — never a raw stack trace to the user.
 let writeErrorShown = false;
-const store = new NoteStore(app.getPath('userData'), {
-  onCorrupted: () => {
-    dialog.showErrorBox(
-      'Notes file was reset',
-      'Your saved notes file could not be read and looked corrupted, so it was backed up and Ghost Notes started fresh. Your previous notes were not deleted — the backup is in the app data folder if you need to recover them.'
-    );
-  },
-  onWriteError: () => {
-    if (writeErrorShown) return;
-    writeErrorShown = true;
-    dialog.showErrorBox(
-      'Could not save notes',
-      'Ghost Notes could not write to its data folder. Check that the app has permission to write there and that the disk is not full. Your notes in memory are safe until you quit.'
-    );
+
+// The store is created lazily inside app.whenReady(): NoteStore reads/writes
+// notes.json synchronously at construction, but safeStorage — which we use to
+// encrypt notes at rest — is only guaranteed to be available after the app is
+// ready. `store`/`manager` are hoisted as `let` and assigned there; every
+// function that touches them is invoked from the ready lifecycle or IPC, both
+// of which run only after app is ready.
+let store = null;
+let manager = null;
+
+// Build the encryption codec used by NoteStore to protect notes.json at rest.
+// safeStorage leverages OS-level encryption (Keychain on macOS, DPAPI on
+// Windows) keyed to the current OS user. We only enable it when the platform
+// actually supports it; otherwise we fall back to plaintext with a warning.
+function createStoreCodec() {
+  if (safeStorage && safeStorage.isEncryptionAvailable()) {
+    return {
+      encrypt: (plain) => safeStorage.encryptString(plain),
+      decrypt: (cipher) => safeStorage.decryptString(cipher)
+    };
   }
-});
+  console.warn(
+    'OS-level storage encryption (safeStorage) is unavailable on this system; ' +
+      'notes will be stored in plaintext.'
+  );
+  return null;
+}
+
+function createStore() {
+  return new NoteStore(app.getPath('userData'), {
+    codec: createStoreCodec(),
+    onCorrupted: () => {
+      dialog.showErrorBox(
+        'Notes file was reset',
+        'Your saved notes file could not be read and looked corrupted, so it was backed up and Ghost Notes started fresh. Your previous notes were not deleted — the backup is in the app data folder if you need to recover them.'
+      );
+    },
+    onWriteError: () => {
+      if (writeErrorShown) return;
+      writeErrorShown = true;
+      dialog.showErrorBox(
+        'Could not save notes',
+        'Ghost Notes could not write to its data folder. Check that the app has permission to write there and that the disk is not full. Your notes in memory are safe until you quit.'
+      );
+    }
+  });
+}
 
 // Open BrowserWindows only — a subset of store records. A record can exist
 // (and be listed in the future Notes Manager) with no entry here at all,
@@ -32,16 +63,21 @@ const store = new NoteStore(app.getPath('userData'), {
 const noteWindows = new Map(); // id -> BrowserWindow
 let tray = null;
 
-const manager = createManagerModule({
-  store,
-  actions: {
-    showNote: (id) => showNote(id),
-    hideNote: (id) => hideNote(id),
-    deleteNoteRecord: (id) => deleteNoteRecord(id),
-    renameNote: (id, title) => renameNote(id, title),
-    createNote: () => createNoteNearCursor()
-  }
-});
+// createManagerModule registers IPC handlers that only act once a renderer
+// sends a message, so it can be created lazily after app is ready alongside
+// `store` (which createManagerModule closes over). See createStore() above.
+function createManager() {
+  return createManagerModule({
+    store,
+    actions: {
+      showNote: (id) => showNote(id),
+      hideNote: (id) => hideNote(id),
+      deleteNoteRecord: (id) => deleteNoteRecord(id),
+      renameNote: (id, title) => renameNote(id, title),
+      createNote: () => createNoteNearCursor()
+    }
+  });
+}
 
 function openNoteWindow(record) {
   const win = createNoteWindow(record, {
@@ -273,6 +309,13 @@ if (!gotLock) {
 
   app.whenReady().then(() => {
     platform.hideDockIconIfMac(app);
+
+    // safeStorage is only guaranteed available after the app is ready, so this
+    // is the earliest safe point to construct the (synchronous) store and wire
+    // up the manager that depends on it.
+    store = createStore();
+    manager = createManager();
+
     setupTray();
 
     const records = store.all();

--- a/store.js
+++ b/store.js
@@ -62,48 +62,98 @@ class NoteStore {
   // onCorrupted(backupPath) and onWriteError(error) are optional hooks so the
   // caller (main.js) can surface a friendly, non-technical notice — this
   // module has no Electron dependency and never shows UI itself.
-  constructor(userDataPath, { onCorrupted, onWriteError } = {}) {
+  //
+  // `codec` is an optional `{ encrypt(string) -> Buffer, decrypt(Buffer) -> string }`
+  // pair that encrypts the file's bytes at rest (typically Electron's
+  // safeStorage). When provided, writes are encrypted and reads are decrypted.
+  // When omitted (e.g. OS-level encryption unavailable), notes are stored as
+  // plaintext — matching the original behavior.
+  constructor(userDataPath, { onCorrupted, onWriteError, codec } = {}) {
     this.filePath = path.join(userDataPath, 'notes.json');
     this.tmpPath = this.filePath + '.tmp';
     this.backupPath = this.filePath + '.corrupt';
     this.onCorrupted = onCorrupted;
     this.onWriteError = onWriteError;
-    this.data = this._load();
+    this.codec = codec || null;
+    const { data, migrated } = this._load();
+    this.data = data;
     this._saveTimer = null;
+    if (migrated && this.codec) {
+      // A legacy plaintext file was loaded while encryption is now enabled —
+      // re-encrypt it immediately so plaintext doesn't linger on disk.
+      this._writeNow();
+    }
   }
 
+  // Returns { data, migrated } where `migrated` indicates a legacy plaintext
+  // file was found while a codec is enabled (and should be re-encrypted).
   _load() {
     let raw;
     try {
-      raw = fs.readFileSync(this.filePath, 'utf8');
+      raw = fs.readFileSync(this.filePath); // Buffer
     } catch (_) {
-      return { version: STORE_VERSION, notes: [] };
+      return { data: { version: STORE_VERSION, notes: [] }, migrated: false };
     }
-    try {
-      const parsed = JSON.parse(raw);
-      if (!parsed || parsed.version !== STORE_VERSION) {
-        // About to run a schema migration — snapshot the pre-migration file
-        // first so a bug in migrate() can never be the only copy of the data.
-        try {
-          fs.writeFileSync(this.filePath + `.pre-migration-v${parsed && parsed.version || 1}`, raw);
-        } catch (_) {}
-      }
-      return migrate(parsed);
-    } catch (e) {
-      // Corrupted file: preserve it for inspection, never destroy silently
-      // by overwriting, start fresh so the app still boots.
+
+    // 1) Encryption enabled: try to decrypt the file first.
+    if (this.codec) {
       try {
-        fs.writeFileSync(this.backupPath, raw);
-      } catch (_) {}
-      console.error('notes.json was corrupted, backed up to', this.backupPath, e);
-      if (this.onCorrupted) this.onCorrupted(this.backupPath);
-      return { version: STORE_VERSION, notes: [] };
+        const plain = this.codec.decrypt(raw);
+        let parsed = null;
+        try {
+          parsed = JSON.parse(plain);
+        } catch (_) {}
+        if (parsed) {
+          return { data: this._parseAndMigrate(parsed, raw), migrated: false };
+        }
+      } catch (_) {
+        // Decryption failed — the file is probably a legacy plaintext file
+        // saved before encryption was enabled. Fall through and migrate it.
+      }
     }
+
+    // 2) Legacy plaintext JSON (or an unreadable/corrupted file).
+    let parsed = null;
+    try {
+      parsed = JSON.parse(raw.toString('utf8'));
+    } catch (_) {
+      return { data: this._corrupt(raw), migrated: false };
+    }
+    return { data: this._parseAndMigrate(parsed, raw), migrated: !!this.codec };
+  }
+
+  _parseAndMigrate(parsed, raw) {
+    if (!parsed || parsed.version !== STORE_VERSION) {
+      // About to run a schema migration — snapshot the pre-migration file
+      // first so a bug in migrate() can never be the only copy of the data.
+      try {
+        fs.writeFileSync(this.filePath + `.pre-migration-v${(parsed && parsed.version) || 1}`, raw);
+      } catch (_) {}
+    }
+    return migrate(parsed);
+  }
+
+  _corrupt(raw) {
+    // Preserve the bad file for inspection, never destroy it silently by
+    // overwriting; start fresh so the app still boots.
+    try {
+      fs.writeFileSync(this.backupPath, raw);
+    } catch (_) {}
+    console.error('notes.json was corrupted, backed up to', this.backupPath);
+    if (this.onCorrupted) this.onCorrupted(this.backupPath);
+    return { version: STORE_VERSION, notes: [] };
   }
 
   _writeNow() {
+    let out;
+    if (this.codec) {
+      // safeStorage.encryptString returns a Buffer; write it as-is.
+      out = this.codec.encrypt(JSON.stringify(this.data));
+    } else {
+      out = Buffer.from(JSON.stringify(this.data, null, 2), 'utf8');
+    }
     try {
-      fs.writeFileSync(this.tmpPath, JSON.stringify(this.data, null, 2));
+      fs.writeFileSync(this.tmpPath, out);
       fs.renameSync(this.tmpPath, this.filePath);
     } catch (e) {
       console.error('Failed to save notes:', e);


### PR DESCRIPTION
Closes #10

## Summary

Encrypts `notes.json` at rest using Electron's `safeStorage` API (Keychain on macOS, DPAPI on Windows), so raw note contents can't be read by other applications or anyone with file-system access. No master-password prompt — the seamless user experience is preserved.

## Changes

- **`store.js`** — `NoteStore` accepts an optional `codec` (`{ encrypt, decrypt }`). Writes are encrypted; reads try to decrypt first, and if that fails they fall back to migrating existing legacy plaintext `notes.json` files (which are immediately re-encrypted on load so plaintext doesn't linger on disk). No codec ⇒ plaintext as before (graceful fallback). Corruption backup behavior is preserved.
- **`main.js`** — `store`/`manager` creation is deferred into `app.whenReady()`, where `safeStorage` is guaranteed available. `createStoreCodec()` enables encryption only when `safeStorage.isEncryptionAvailable()`, otherwise logs a console warning and falls back to plaintext. Existing `onCorrupted`/`onWriteError` dialogs are unchanged.

## Validation

- `node --check` passes for both files.
- Added a temporary Node test (13 assertions) covering: encrypted roundtrip, legacy plaintext → encrypted migration on disk, plaintext fallback, corrupted-file backup with and without a codec, and v1 schema migration. All passed; the test file was not committed.

## Checklist

- [x] Use `safeStorage.encryptString()`/`decryptString()` in `store.js`
- [x] Defer `NoteStore` init until `app.whenReady()`
- [x] Migration path for existing plaintext `notes.json`
- [x] Error handling / fallback when `safeStorage` is unavailable