### PR TITLE
feat: add workspaces to group notes and switch visibility by group

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,7 +91,12 @@ function createManager() {
       renameNote: (id, title) => renameNote(id, title),
       createNote: () => createNoteNearCursor(),
       toggleHideAll: () => toggleHideAll(),
-      toggleGhostAll: () => toggleGhostAll()
+      toggleGhostAll: () => toggleGhostAll(),
+      setActiveWorkspace: (id) => setActiveWorkspace(id),
+      createWorkspace: (name) => createWorkspace(name),
+      renameWorkspace: (id, name) => renameWorkspace(id, name),
+      removeWorkspace: (id) => removeWorkspace(id),
+      moveNoteToWorkspace: (noteId, workspaceId) => moveNoteToWorkspace(noteId, workspaceId)
     }
   });
 }
@@ -121,19 +126,63 @@ function openNoteWindow(record) {
   return win;
 }
 
-function showNote(id) {
+// ---------- Window vs. record (issue #8) ----------
+//
+// A note is on screen when BOTH are true:
+//
+//     record.visible === true            (the user's own show/hide choice)
+//     record.workspaceId === active      (its workspace is the one selected)
+//
+// The two are deliberately independent. openWindowFor/closeWindowFor touch
+// only the window, so switching workspaces can pull notes off screen and put
+// them back without ever rewriting `visible`. Otherwise, leaving 2 of 5 notes
+// open, switching away and switching back would return all 5, silently
+// destroying the user's per-note choices on every switch.
+//
+// showNote/hideNote are the record-writing pair, used when the user really
+// does mean "show/hide this note" (the X button, the tray, the manager).
+
+function openWindowFor(id) {
   const existing = noteWindows.get(id);
   if (existing && !existing.isDestroyed()) {
     existing.showInactive();
     // Re-apply capture exclusion: some Electron versions on Windows clear the
     // SetWindowDisplayAffinity flag when a window is hidden via win.hide().
     applyContentProtection(existing);
-  } else {
-    const record = store.get(id);
-    if (!record) return;
-    openNoteWindow(record);
+    return existing;
   }
+  const record = store.get(id);
+  if (!record) return null;
+  return openNoteWindow(record);
+}
+
+// Pull a note off screen without touching its record. Intentionally
+// hide() and not close()/destroy(), because the window is reused when its
+// workspace comes back, which keeps the switch instant.
+function closeWindowFor(id) {
+  const win = noteWindows.get(id);
+  if (win && !win.isDestroyed()) win.hide();
+}
+
+// Reconcile every window against the active workspace. Doubles as the
+// startup path: notes that are visible in the active workspace get windows,
+// everything else stays off screen with its `visible` flag intact.
+function applyActiveWorkspace() {
+  const activeId = store.activeWorkspaceId();
+  for (const record of store.all()) {
+    if (record.visible && record.workspaceId === activeId) openWindowFor(record.id);
+    else closeWindowFor(record.id);
+  }
+}
+
+function showNote(id) {
+  const record = store.get(id);
+  if (!record) return;
   store.update(id, { visible: true });
+  // Only notes in the active workspace get a window; a note shown while
+  // another workspace is selected stays marked visible and appears as soon
+  // as its workspace is selected again.
+  if (record.workspaceId === store.activeWorkspaceId()) openWindowFor(id);
   updateTrayMenu();
   manager.notifyChanged();
 }
@@ -142,8 +191,7 @@ function showNote(id) {
 // (and its content) stays in the store untouched. This is intentionally
 // NOT window.close()/destroy() — only Notes Manager delete removes a record.
 function hideNote(id) {
-  const win = noteWindows.get(id);
-  if (win && !win.isDestroyed()) win.hide();
+  closeWindowFor(id);
   store.update(id, { visible: false });
   updateTrayMenu();
   manager.notifyChanged();
@@ -164,6 +212,49 @@ function renameNote(id, title) {
   manager.notifyChanged();
 }
 
+// ---------- Workspaces ----------
+function setActiveWorkspace(id) {
+  if (!store.setActiveWorkspace(id)) return;
+  applyActiveWorkspace();
+  updateTrayMenu();
+  manager.notifyChanged();
+}
+
+// Creating a workspace switches to it, because the user just named the context
+// they want to work in, so landing them somewhere else would be surprising.
+function createWorkspace(name) {
+  const workspace = store.createWorkspace(name);
+  setActiveWorkspace(workspace.id);
+  return workspace;
+}
+
+function renameWorkspace(id, name) {
+  store.renameWorkspace(id, name);
+  updateTrayMenu();
+  manager.notifyChanged();
+}
+
+// Notes in the removed workspace are reassigned, never deleted (see
+// NoteStore.removeWorkspace). Returns the store's result so the caller can
+// tell the user how many notes moved.
+function removeWorkspace(id) {
+  const result = store.removeWorkspace(id);
+  if (!result) return null;
+  applyActiveWorkspace();
+  updateTrayMenu();
+  manager.notifyChanged();
+  return result;
+}
+
+function moveNoteToWorkspace(noteId, workspaceId) {
+  if (!store.moveNote(noteId, workspaceId)) return;
+  // The note may have just moved out of (or into) the active workspace, so
+  // its window has to follow, without disturbing its `visible` flag.
+  applyActiveWorkspace();
+  updateTrayMenu();
+  manager.notifyChanged();
+}
+
 function createNoteNearCursor() {
   const cursor = screen.getCursorScreenPoint();
   const display = screen.getDisplayNearestPoint(cursor);
@@ -179,16 +270,25 @@ function createNoteNearCursor() {
   return record.id;
 }
 
+// Scoped to the active workspace, because "hide all" should never reach into a
+// workspace the user isn't looking at and rewrite its notes' visibility.
 function toggleHideAll() {
-  const anyVisible = store.all().some((n) => n.visible);
-  for (const record of store.all()) {
+  const records = store.notesInWorkspace(store.activeWorkspaceId());
+  const anyVisible = records.some((n) => n.visible);
+  for (const record of records) {
     if (anyVisible) hideNote(record.id);
     else showNote(record.id);
   }
 }
 
+// Also scoped to the active workspace. Windows for other workspaces are
+// hidden rather than destroyed, so an unscoped loop would silently flip
+// click-through on notes the user can't even see.
 function toggleGhostAll() {
-  for (const win of noteWindows.values()) {
+  const activeId = store.activeWorkspaceId();
+  for (const [id, win] of noteWindows) {
+    const record = store.get(id);
+    if (!record || record.workspaceId !== activeId) continue;
     if (!win.isDestroyed()) win.webContents.send('note:toggleGhost');
   }
 }
@@ -272,23 +372,40 @@ function noteLabel(record) {
   return snippet || 'Untitled note';
 }
 
-// Stopgap until the full Notes Manager window (step 2) exists: lists every
-// saved record, open or hidden, so a hidden note is never actually stranded.
+// Lists the active workspace's records, open or hidden, so a hidden note is
+// never stranded. Notes in other workspaces are reachable by switching to
+// that workspace from the Workspace submenu.
 function buildNotesSubmenu() {
-  const records = store.all();
-  if (records.length === 0) return [{ label: 'No notes yet', enabled: false }];
+  const records = store.notesInWorkspace(store.activeWorkspaceId());
+  if (records.length === 0) return [{ label: 'No notes in this workspace', enabled: false }];
   return records.map((record) => ({
     label: `${record.visible ? '●' : '○'} ${noteLabel(record)}`,
     click: () => (record.visible ? hideNote(record.id) : showNote(record.id))
   }));
 }
 
+// Radio items so the active workspace is unambiguous at a glance; the note
+// count makes it obvious where notes went after a switch.
+function buildWorkspaceSubmenu() {
+  const activeId = store.activeWorkspaceId();
+  return store.workspaces().map((workspace) => ({
+    label: `${workspace.name} (${store.notesInWorkspace(workspace.id).length})`,
+    type: 'radio',
+    checked: workspace.id === activeId,
+    click: () => setActiveWorkspace(workspace.id)
+  }));
+}
+
 function updateTrayMenu() {
   if (!tray) return;
   const caveat = platform.captureExclusionCaveat();
+  const activeWorkspace = store.getWorkspace(store.activeWorkspaceId());
   const menu = Menu.buildFromTemplate([
     { label: 'New Note', accelerator: 'CmdOrCtrl+Shift+N', click: () => createNoteNearCursor() },
     { label: 'Notes Manager…', accelerator: 'CmdOrCtrl+Shift+M', click: () => manager.openManagerWindow() },
+    { type: 'separator' },
+    { label: `Workspace: ${activeWorkspace ? activeWorkspace.name : '(none)'}`, enabled: false },
+    { label: 'Switch Workspace', submenu: buildWorkspaceSubmenu() },
     { label: 'Notes', submenu: buildNotesSubmenu() },
     { label: 'Hide/Show All', accelerator: 'CmdOrCtrl+Shift+H', click: () => toggleHideAll() },
     { label: 'Toggle Click-Through (all)', accelerator: 'CmdOrCtrl+Shift+G', click: () => toggleGhostAll() },
@@ -343,13 +460,12 @@ if (!gotLock) {
     setupTray();
     registerFallbackShortcut(globalShortcut, () => createNoteNearCursor());
 
-    const records = store.all();
-    if (records.length === 0) {
+    if (store.all().length === 0) {
       createNoteNearCursor();
     } else {
-      for (const record of records) {
-        if (record.visible) openNoteWindow(record);
-      }
+      // Restores exactly the notes that are visible AND in the active
+      // workspace, which is the same rule that governs a workspace switch.
+      applyActiveWorkspace();
     }
 
     screen.on('display-added', reconcileOpenWindowsToDisplays);

--- a/manager-preload.js
+++ b/manager-preload.js
@@ -7,6 +7,12 @@ contextBridge.exposeInMainWorld('manager', {
   delete: (id) => ipcRenderer.send('manager:delete', id),
   rename: (id, title) => ipcRenderer.send('manager:rename', { id, title }),
   newNote: () => ipcRenderer.send('manager:new'),
-  onChanged: (cb) => ipcRenderer.on('manager:notesChanged', (e, notes) => cb(notes)),
-  version: () => ipcRenderer.invoke('manager:version')
+  onChanged: (cb) => ipcRenderer.on('manager:notesChanged', (e, snapshot) => cb(snapshot)),
+  version: () => ipcRenderer.invoke('manager:version'),
+  // Workspaces (issue #8)
+  setWorkspace: (id) => ipcRenderer.send('manager:setWorkspace', id),
+  createWorkspace: (name) => ipcRenderer.send('manager:createWorkspace', name),
+  renameWorkspace: (id, name) => ipcRenderer.send('manager:renameWorkspace', { id, name }),
+  deleteWorkspace: (id) => ipcRenderer.send('manager:deleteWorkspace', id),
+  moveNote: (id, workspaceId) => ipcRenderer.send('manager:moveNote', { id, workspaceId })
 });

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -16,9 +16,17 @@ const ICONS = {
 
 const listEl = document.getElementById('list');
 const searchEl = document.getElementById('search');
+const workspaceSelectEl = document.getElementById('workspaceSelect');
+const wsFormEl = document.getElementById('wsForm');
+const wsNameInputEl = document.getElementById('wsNameInput');
+const wsDeleteEl = document.getElementById('wsDelete');
 
 let notes = [];
+let workspaces = [];
+let activeWorkspace = null;
 let query = '';
+// null when the inline name row is closed, otherwise 'create' | 'rename'.
+let formMode = null;
 
 function label(note) {
   return (note.title || '').trim();
@@ -48,15 +56,18 @@ function matches(note, q) {
 }
 
 function render() {
-  const filtered = notes
+  // The list only ever shows the active workspace, since switching workspace is
+  // what changes which notes are on screen, so the manager mirrors that.
+  const inWorkspace = notes.filter((n) => n.workspaceId === activeWorkspace);
+  const filtered = inWorkspace
     .slice()
     .sort((a, b) => b.updatedAt - a.updatedAt)
     .filter((n) => matches(n, query));
 
   listEl.innerHTML = '';
 
-  if (notes.length === 0) {
-    listEl.innerHTML = `<div class="empty">${ICONS.notes}<div>No notes yet.<br/>Click "New" or press &#8984;&#8679;N (Ctrl+Shift+N) to create one.</div></div>`;
+  if (inWorkspace.length === 0) {
+    listEl.innerHTML = `<div class="empty">${ICONS.notes}<div>No notes in this workspace.<br/>Click "New" or press &#8984;&#8679;N (Ctrl+Shift+N) to create one.</div></div>`;
     return;
   }
   if (filtered.length === 0) {
@@ -99,6 +110,29 @@ function render() {
     const actions = document.createElement('div');
     actions.className = 'actions';
 
+    // Move-to-workspace. Pointless with only one workspace, so it isn't
+    // rendered until a second one exists.
+    if (workspaces.length > 1) {
+      const moveSelect = document.createElement('select');
+      moveSelect.className = 'move-select';
+      moveSelect.title = 'Move to workspace';
+      moveSelect.setAttribute('aria-label', 'Move note to workspace');
+      for (const workspace of workspaces) {
+        const opt = document.createElement('option');
+        opt.value = workspace.id;
+        opt.textContent = workspace.name;
+        opt.selected = workspace.id === note.workspaceId;
+        moveSelect.appendChild(opt);
+      }
+      moveSelect.addEventListener('change', () => {
+        window.manager.moveNote(note.id, moveSelect.value);
+      });
+      // The card opens the note on double-click; don't let clicks in the
+      // dropdown bubble up to that handler.
+      moveSelect.addEventListener('dblclick', (e) => e.stopPropagation());
+      actions.appendChild(moveSelect);
+    }
+
     const deleteBtn = document.createElement('button');
     deleteBtn.className = 'icon-btn danger';
     deleteBtn.title = 'Delete permanently';
@@ -120,6 +154,66 @@ function render() {
   }
 }
 
+// ─── Workspaces (issue #8) ──────────────────────────────────────
+function renderWorkspaces() {
+  workspaceSelectEl.innerHTML = '';
+  for (const workspace of workspaces) {
+    const count = notes.filter((n) => n.workspaceId === workspace.id).length;
+    const opt = document.createElement('option');
+    opt.value = workspace.id;
+    opt.textContent = `${workspace.name} (${count})`;
+    opt.selected = workspace.id === activeWorkspace;
+    workspaceSelectEl.appendChild(opt);
+  }
+  // The last workspace can't be deleted. The store refuses, so don't
+  // offer it either.
+  wsDeleteEl.disabled = workspaces.length <= 1;
+}
+
+// Electron disables window.prompt(), so create/rename share this inline row
+// rather than a native text dialog.
+function openWorkspaceForm(mode) {
+  formMode = mode;
+  const current = workspaces.find((w) => w.id === activeWorkspace);
+  wsNameInputEl.value = mode === 'rename' && current ? current.name : '';
+  wsFormEl.hidden = false;
+  wsNameInputEl.focus();
+  wsNameInputEl.select();
+}
+
+function closeWorkspaceForm() {
+  formMode = null;
+  wsFormEl.hidden = true;
+  wsNameInputEl.value = '';
+}
+
+workspaceSelectEl.addEventListener('change', () => {
+  closeWorkspaceForm();
+  window.manager.setWorkspace(workspaceSelectEl.value);
+});
+
+document.getElementById('wsNew').addEventListener('click', () => openWorkspaceForm('create'));
+document.getElementById('wsRename').addEventListener('click', () => openWorkspaceForm('rename'));
+wsDeleteEl.addEventListener('click', () => window.manager.deleteWorkspace(activeWorkspace));
+document.getElementById('wsCancel').addEventListener('click', () => closeWorkspaceForm());
+
+wsFormEl.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = wsNameInputEl.value.trim();
+  if (!name) {
+    closeWorkspaceForm();
+    return;
+  }
+  if (formMode === 'create') window.manager.createWorkspace(name);
+  else if (formMode === 'rename') window.manager.renameWorkspace(activeWorkspace, name);
+  closeWorkspaceForm();
+});
+
+wsNameInputEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeWorkspaceForm();
+});
+
+// ─── Notes ──────────────────────────────────────────────────────
 searchEl.addEventListener('input', () => {
   query = searchEl.value;
   render();
@@ -127,15 +221,18 @@ searchEl.addEventListener('input', () => {
 
 document.getElementById('newNote').addEventListener('click', () => window.manager.newNote());
 
-window.manager.onChanged((updated) => {
-  notes = updated;
+// Notes and workspaces always arrive together so the list can never render
+// against a stale workspace set.
+function applySnapshot(snapshot) {
+  notes = snapshot.notes || [];
+  workspaces = snapshot.workspaces || [];
+  activeWorkspace = snapshot.activeWorkspace || null;
+  renderWorkspaces();
   render();
-});
+}
 
-window.manager.list().then((initial) => {
-  notes = initial;
-  render();
-});
+window.manager.onChanged(applySnapshot);
+window.manager.list().then(applySnapshot);
 
 window.manager.version().then((v) => {
   document.getElementById('version').textContent = 'Ghost Notes v' + v;

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -11,7 +11,8 @@ const ICONS = {
   eye: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>',
   eyeOff: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24M1 1l22 22"/></svg>',
   trash: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0-1 14a2 2 0 01-2 2H7a2 2 0 01-2-2L4 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>',
-  notes: '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h12l4 4v12H4z"/><path d="M16 4v4h4"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="13" y2="16"/></svg>'
+  notes: '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h12l4 4v12H4z"/><path d="M16 4v4h4"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="13" y2="16"/></svg>',
+  move: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h6"/><path d="m17 15 3 3-3 3"/><path d="M13 18h7"/></svg>'
 };
 
 const listEl = document.getElementById('list');
@@ -113,9 +114,15 @@ function render() {
     // Move-to-workspace. Pointless with only one workspace, so it isn't
     // rendered until a second one exists.
     if (workspaces.length > 1) {
+      // The icon is what the user sees; the select is transparent on top of
+      // it so clicking anywhere on the icon opens the native workspace list.
+      const moveWrap = document.createElement('span');
+      moveWrap.className = 'move-wrap';
+      moveWrap.title = 'Move to workspace';
+      moveWrap.innerHTML = ICONS.move;
+
       const moveSelect = document.createElement('select');
       moveSelect.className = 'move-select';
-      moveSelect.title = 'Move to workspace';
       moveSelect.setAttribute('aria-label', 'Move note to workspace');
       for (const workspace of workspaces) {
         const opt = document.createElement('option');
@@ -130,7 +137,9 @@ function render() {
       // The card opens the note on double-click; don't let clicks in the
       // dropdown bubble up to that handler.
       moveSelect.addEventListener('dblclick', (e) => e.stopPropagation());
-      actions.appendChild(moveSelect);
+
+      moveWrap.appendChild(moveSelect);
+      actions.appendChild(moveWrap);
     }
 
     const deleteBtn = document.createElement('button');

--- a/manager.html
+++ b/manager.html
@@ -23,6 +23,15 @@
     --sh-hover:    0 6px 18px rgba(20,20,30,0.08), 0 1px 3px rgba(20,20,30,0.05);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  .sr-only {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
   html, body {
     height: 100%;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -92,6 +101,92 @@
   }
   .btn:hover { background: var(--accent-dk); }
   .btn:active { transform: scale(0.97); }
+
+  /* ─── Workspace bar (issue #8) ────────────────────────── */
+  .wsbar {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-2);
+  }
+
+  .ws-select-wrap {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+  .ws-select-wrap > svg {
+    position: absolute;
+    left: 10px;
+    color: var(--accent);
+    pointer-events: none;
+  }
+  .ws-select-wrap::after {
+    content: "";
+    position: absolute;
+    right: 11px;
+    width: 7px;
+    height: 7px;
+    border-right: 1.8px solid var(--muted);
+    border-bottom: 1.8px solid var(--muted);
+    transform: rotate(45deg) translate(-2px, -2px);
+    pointer-events: none;
+  }
+  #workspaceSelect {
+    width: 100%;
+    appearance: none;
+    -webkit-appearance: none;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    border-radius: 8px;
+    padding: 8px 28px 8px 30px;
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    color: var(--ink);
+    outline: none;
+    cursor: pointer;
+    text-overflow: ellipsis;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  #workspaceSelect:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-lt);
+  }
+
+  /* Inline create/rename row. Electron disables window.prompt(), so the
+     name is captured in the page rather than a native dialog. */
+  .ws-form {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--accent-lt);
+  }
+  .ws-form[hidden] { display: none; }
+  #wsNameInput {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid var(--border-2);
+    background: var(--surface);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 13px;
+    font-family: inherit;
+    color: var(--ink);
+    outline: none;
+  }
+  #wsNameInput:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(91, 75, 255, 0.15);
+  }
 
   /* ─── List ────────────────────────────────────────────── */
   .list {
@@ -212,6 +307,28 @@
     flex: 0 0 auto;
   }
 
+  /* Per-card "move to workspace" control. Only rendered when more than one
+     workspace exists, so a single-workspace user never sees it. */
+  .move-select {
+    max-width: 30px;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    padding: 6px 4px;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--muted);
+    cursor: pointer;
+    outline: none;
+    transition: background 0.15s, color 0.15s, max-width 0.15s;
+  }
+  .move-select:hover,
+  .move-select:focus {
+    max-width: 120px;
+    background: var(--surface-2);
+    color: var(--ink);
+  }
+
   #version {
     flex: 0 0 auto;
     padding: 8px 12px;
@@ -224,6 +341,31 @@
 </style>
 </head>
 <body>
+  <div class="wsbar">
+    <div class="ws-select-wrap">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+      <select id="workspaceSelect" aria-label="Active workspace"></select>
+    </div>
+    <button class="icon-btn" id="wsNew" title="New workspace" aria-label="New workspace">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+    </button>
+    <button class="icon-btn" id="wsRename" title="Rename workspace" aria-label="Rename workspace">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>
+    </button>
+    <button class="icon-btn danger" id="wsDelete" title="Delete workspace" aria-label="Delete workspace">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0-1 14a2 2 0 01-2 2H7a2 2 0 01-2-2L4 6"/></svg>
+    </button>
+  </div>
+
+  <form class="ws-form" id="wsForm" hidden>
+    <label class="sr-only" for="wsNameInput">Workspace name</label>
+    <input id="wsNameInput" type="text" maxlength="40" placeholder="Workspace name…" autocomplete="off" />
+    <button type="submit" class="btn" id="wsSave">Save</button>
+    <button type="button" class="icon-btn" id="wsCancel" title="Cancel" aria-label="Cancel">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    </button>
+  </form>
+
   <div class="toolbar">
     <div class="search-wrap">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>

--- a/manager.html
+++ b/manager.html
@@ -308,26 +308,51 @@
   }
 
   /* Per-card "move to workspace" control. Only rendered when more than one
-     workspace exists, so a single-workspace user never sees it. */
-  .move-select {
-    max-width: 30px;
-    border: none;
-    background: transparent;
+     workspace exists, so a single-workspace user never sees it.
+     The icon is the visible affordance and the select sits transparently on
+     top of it, sized to match .icon-btn. Showing the select's own label here
+     would render a clipped fragment of the workspace name next to a native
+     arrow inside 30px, and widening it on hover shifted the card layout. */
+  .move-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    flex: 0 0 auto;
     border-radius: 8px;
-    padding: 6px 4px;
-    font-size: 12px;
-    font-family: inherit;
     color: var(--muted);
-    cursor: pointer;
-    outline: none;
-    transition: background 0.15s, color 0.15s, max-width 0.15s;
+    transition: background 0.15s, color 0.15s;
   }
-  .move-select:hover,
-  .move-select:focus {
-    max-width: 120px;
+  .move-wrap:hover { background: var(--surface-2); color: var(--ink); }
+  .move-wrap:focus-within {
     background: var(--surface-2);
     color: var(--ink);
+    box-shadow: 0 0 0 2px var(--accent-lt);
   }
+  .move-wrap > svg { pointer-events: none; }
+
+  .move-select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    color: transparent;
+    font-family: inherit;
+    cursor: pointer;
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
+  }
+  /* The open dropdown is a native widget rendered outside the page's own
+     styling, so it does not inherit the transparent colour above and the
+     options need one of their own to stay readable. */
+  .move-select option { color: var(--ink); }
 
   #version {
     flex: 0 0 auto;

--- a/manager.js
+++ b/manager.js
@@ -114,9 +114,12 @@ function createManagerModule({ store, actions }) {
 
     const noteCount = store.notesInWorkspace(id).length;
     const plural = noteCount === 1 ? '' : 's';
+    // Name the workspace the notes will actually land in. Hardcoding
+    // "Default" is wrong once that workspace has been renamed or deleted.
+    const fallback = store.fallbackWorkspaceFor(id);
     const detail = noteCount === 0
       ? 'This workspace is empty. No notes will be affected.'
-      : `Its ${noteCount} note${plural} will be moved to your Default workspace, not deleted.`;
+      : `Its ${noteCount} note${plural} will be moved to "${fallback.name}", not deleted.`;
 
     const targetWindow = BrowserWindow.fromWebContents(e.sender) || undefined;
     const { response } = await dialog.showMessageBox(targetWindow, {

--- a/manager.js
+++ b/manager.js
@@ -5,6 +5,7 @@
 const path = require('path');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const { registerShortcuts } = require('./shortcuts');
+const { sanitizeWorkspaceName } = require('./store');
 
 const MAX_TITLE_LENGTH = 80;
 
@@ -16,9 +17,20 @@ function sanitizeTitle(input) {
 function createManagerModule({ store, actions }) {
   let win = null;
 
+  // One payload for both the initial load and every update, so the renderer
+  // always sees notes and workspaces from the same consistent snapshot. A
+  // note can never render against a workspace list that doesn't contain it.
+  function snapshot() {
+    return {
+      notes: store.all(),
+      workspaces: store.workspaces(),
+      activeWorkspace: store.activeWorkspaceId()
+    };
+  }
+
   function notifyChanged() {
     if (win && !win.isDestroyed()) {
-      win.webContents.send('manager:notesChanged', store.all());
+      win.webContents.send('manager:notesChanged', snapshot());
     }
   }
 
@@ -55,8 +67,69 @@ function createManagerModule({ store, actions }) {
     });
   }
 
-  ipcMain.handle('manager:list', () => store.all());
+  ipcMain.handle('manager:list', () => snapshot());
   ipcMain.handle('manager:version', () => app.getVersion());
+
+  // ---------- Workspaces (issue #8) ----------
+  ipcMain.on('manager:setWorkspace', (e, id) => {
+    if (typeof id !== 'string') return;
+    actions.setActiveWorkspace(id);
+  });
+
+  ipcMain.on('manager:createWorkspace', (e, name) => {
+    const clean = sanitizeWorkspaceName(name);
+    if (!clean) return;
+    actions.createWorkspace(clean);
+  });
+
+  ipcMain.on('manager:renameWorkspace', (e, payload) => {
+    if (!payload || typeof payload.id !== 'string') return;
+    const clean = sanitizeWorkspaceName(payload.name);
+    if (!clean) return;
+    actions.renameWorkspace(payload.id, clean);
+  });
+
+  ipcMain.on('manager:moveNote', (e, payload) => {
+    if (!payload || typeof payload.id !== 'string' || typeof payload.workspaceId !== 'string') return;
+    actions.moveNoteToWorkspace(payload.id, payload.workspaceId);
+  });
+
+  // Deleting a workspace never deletes notes, it reassigns them. The
+  // confirmation says so explicitly, and names the count, so the user is
+  // never guessing what happens to the notes inside.
+  ipcMain.on('manager:deleteWorkspace', async (e, id) => {
+    if (typeof id !== 'string') return;
+    const workspace = store.getWorkspace(id);
+    if (!workspace) return;
+    if (store.workspaces().length <= 1) {
+      await dialog.showMessageBox(BrowserWindow.fromWebContents(e.sender) || undefined, {
+        type: 'info',
+        buttons: ['OK'],
+        title: 'Cannot delete workspace',
+        message: 'This is your only workspace.',
+        detail: 'Create another workspace first. Ghost Notes always keeps at least one.'
+      });
+      return;
+    }
+
+    const noteCount = store.notesInWorkspace(id).length;
+    const plural = noteCount === 1 ? '' : 's';
+    const detail = noteCount === 0
+      ? 'This workspace is empty. No notes will be affected.'
+      : `Its ${noteCount} note${plural} will be moved to your Default workspace, not deleted.`;
+
+    const targetWindow = BrowserWindow.fromWebContents(e.sender) || undefined;
+    const { response } = await dialog.showMessageBox(targetWindow, {
+      type: 'warning',
+      buttons: ['Cancel', 'Delete workspace'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Delete workspace',
+      message: `Delete the workspace "${workspace.name}"?`,
+      detail
+    });
+    if (response === 1) actions.removeWorkspace(id);
+  });
 
   ipcMain.on('manager:new', () => actions.createNote());
 

--- a/store.js
+++ b/store.js
@@ -35,8 +35,13 @@ function sanitizeWorkspaceName(input) {
 }
 
 function defaultWorkspace(overrides = {}) {
+  // A blank or whitespace-only id is not a usable identifier, so it is
+  // replaced rather than stored. Notes still pointing at the old value are
+  // reattached by normalizeWorkspaces, which reassigns any workspaceId that
+  // does not match a workspace that exists.
+  const id = typeof overrides.id === 'string' ? overrides.id.trim() : '';
   return {
-    id: overrides.id || nextWorkspaceId(),
+    id: id || nextWorkspaceId(),
     name: sanitizeWorkspaceName(overrides.name) || 'Untitled workspace',
     createdAt: overrides.createdAt || Date.now()
   };
@@ -105,12 +110,19 @@ function normalizeWorkspaces(data) {
   // Drop malformed entries and duplicate ids. A duplicate id would put two
   // identical-looking options in the dropdown while only one of them could
   // ever be selected, and would make note membership ambiguous.
+  //
+  // Normalize before deduping, so the check runs against the id actually
+  // being stored. Deduping on the raw value would treat two entries with a
+  // blank id as the same workspace and drop the second, even though
+  // defaultWorkspace gives each of them a distinct generated id.
   const seenIds = new Set();
   let workspaces = [];
-  for (const w of Array.isArray(data.workspaces) ? data.workspaces : []) {
-    if (!w || typeof w.id !== 'string' || seenIds.has(w.id)) continue;
-    seenIds.add(w.id);
-    workspaces.push(defaultWorkspace(w));
+  for (const entry of Array.isArray(data.workspaces) ? data.workspaces : []) {
+    if (!entry || typeof entry !== 'object') continue;
+    const workspace = defaultWorkspace(entry);
+    if (seenIds.has(workspace.id)) continue;
+    seenIds.add(workspace.id);
+    workspaces.push(workspace);
   }
 
   if (workspaces.length === 0) {

--- a/store.js
+++ b/store.js
@@ -146,15 +146,23 @@ function migrate(data) {
   if (!data || typeof data !== 'object') return emptyStore();
   if (!Array.isArray(data.notes)) return emptyStore();
 
+  // Drop entries that are not objects before anything reads fields off them.
+  // A hand-edited or partially written file can hold a null or a bare number
+  // in the array, and every branch below (and normalizeWorkspaces after it)
+  // dereferences each entry. Reading `n.monospace` off a null throws, and the
+  // throw escapes _load's JSON.parse try block, so it would surface as a
+  // crash on launch rather than the corrupt-file recovery path.
+  const sourceNotes = data.notes.filter((n) => n && typeof n === 'object');
+
   let notes;
   if (!data.version) {
     // v1 -> current: add visible/title/displayId/pinned/monospace/timestamps.
-    notes = data.notes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }));
+    notes = sourceNotes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }));
   } else if (data.version === 2) {
     // v2 -> current: backfill pinned:true so existing notes keep today's
     // always-on-top behavior unchanged. Monospace defaults to off unless
     // the record already has it set.
-    notes = data.notes.map((n) => ({
+    notes = sourceNotes.map((n) => ({
       ...n,
       pinned: n.pinned !== undefined ? !!n.pinned : true,
       monospace: !!n.monospace
@@ -163,9 +171,9 @@ function migrate(data) {
     // v3 -> v4: existing notes stay proportional unless the user toggles {}.
     // v4/v5 -> v6: the workspace backfill below is the only change; spreading
     // keeps any fields this version doesn't know about (e.g. v5 `images`).
-    notes = data.notes.map((n) => ({ ...n, monospace: !!n.monospace }));
+    notes = sourceNotes.map((n) => ({ ...n, monospace: !!n.monospace }));
   } else {
-    notes = data.notes;
+    notes = sourceNotes;
   }
 
   // Every pre-v6 file predates workspaces, so normalizeWorkspaces drops all

--- a/store.js
+++ b/store.js
@@ -4,10 +4,36 @@
 const fs = require('fs');
 const path = require('path');
 
-const STORE_VERSION = 4;
+const STORE_VERSION = 6;
+
+// Every install has at least one workspace and it can never be deleted, so a
+// fixed id keeps migrations and the "where do orphaned notes go" fallback
+// simple, with no lookup needed to find a guaranteed-valid destination.
+const DEFAULT_WORKSPACE_ID = 'ws-default';
+const DEFAULT_WORKSPACE_NAME = 'Default';
+const MAX_WORKSPACE_NAME_LENGTH = 40;
 
 function nextId() {
   return 'note-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+}
+
+function nextWorkspaceId() {
+  return 'ws-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+}
+
+// Workspace names are shown in a tray menu, where a newline or an
+// over-long string would break the layout, so normalize at the boundary.
+function sanitizeWorkspaceName(input) {
+  if (typeof input !== 'string') return '';
+  return input.replace(/[\r\n]+/g, ' ').trim().slice(0, MAX_WORKSPACE_NAME_LENGTH);
+}
+
+function defaultWorkspace(overrides = {}) {
+  return {
+    id: overrides.id || nextWorkspaceId(),
+    name: sanitizeWorkspaceName(overrides.name) || 'Untitled workspace',
+    createdAt: overrides.createdAt || Date.now()
+  };
 }
 
 function defaultRecord(overrides = {}) {
@@ -26,6 +52,9 @@ function defaultRecord(overrides = {}) {
     fontSize: overrides.fontSize || 15,
     // Per-note monospace toggle for code walkthroughs (issue #7).
     monospace: !!overrides.monospace,
+    // Which workspace this note belongs to (issue #8). Independent of
+    // `visible`. See the note on effective visibility below.
+    workspaceId: overrides.workspaceId || DEFAULT_WORKSPACE_ID,
     ghost: !!overrides.ghost,
     visible: overrides.visible !== undefined ? !!overrides.visible : true,
     // Pinned = always-on-top, survives switching focus to another app.
@@ -36,41 +65,97 @@ function defaultRecord(overrides = {}) {
   };
 }
 
+function emptyStore() {
+  const workspace = defaultWorkspace({
+    id: DEFAULT_WORKSPACE_ID,
+    name: DEFAULT_WORKSPACE_NAME
+  });
+  return {
+    version: STORE_VERSION,
+    settings: { activeWorkspace: workspace.id },
+    workspaces: [workspace],
+    notes: []
+  };
+}
+
+// Guarantees the workspace invariants the rest of the app relies on:
+//   1. at least one workspace always exists,
+//   2. every note points at a workspace that exists,
+//   3. settings.activeWorkspace points at a workspace that exists.
+// Applied to every load, not just migrations, so a hand-edited or
+// partially-written file can't leave notes stranded in a workspace that
+// isn't in the dropdown, which would make them unreachable from the UI.
+function normalizeWorkspaces(data) {
+  // Drop malformed entries and duplicate ids. A duplicate id would put two
+  // identical-looking options in the dropdown while only one of them could
+  // ever be selected, and would make note membership ambiguous.
+  const seenIds = new Set();
+  let workspaces = [];
+  for (const w of Array.isArray(data.workspaces) ? data.workspaces : []) {
+    if (!w || typeof w.id !== 'string' || seenIds.has(w.id)) continue;
+    seenIds.add(w.id);
+    workspaces.push(defaultWorkspace(w));
+  }
+
+  if (workspaces.length === 0) {
+    workspaces = [defaultWorkspace({ id: DEFAULT_WORKSPACE_ID, name: DEFAULT_WORKSPACE_NAME })];
+  }
+
+  const ids = new Set(workspaces.map((w) => w.id));
+  const fallbackId = ids.has(DEFAULT_WORKSPACE_ID) ? DEFAULT_WORKSPACE_ID : workspaces[0].id;
+
+  const notes = data.notes.map((n) => ({
+    ...n,
+    workspaceId: ids.has(n.workspaceId) ? n.workspaceId : fallbackId
+  }));
+
+  const requested = data.settings?.activeWorkspace;
+  return {
+    version: STORE_VERSION,
+    // Spread first so future app-level settings (theme in #2, custom
+    // shortcuts in #5) survive a workspace migration untouched.
+    settings: { ...data.settings, activeWorkspace: ids.has(requested) ? requested : fallbackId },
+    workspaces,
+    notes
+  };
+}
+
 // v1 files were `{ notes: [...] }` with no `version` field and no `visible`/`title`.
 // v2 files have a version field but no `pinned`.
 // v3 files have pinned but no `monospace`.
+// v4 files have monospace but no workspaces.
+// v5 is the `images` schema from #9, accepted here as a migration source too,
+// so this change and that one are independent of merge order.
 function migrate(data) {
-  if (!data || typeof data !== 'object') return { version: STORE_VERSION, notes: [] };
-  if (!Array.isArray(data.notes)) return { version: STORE_VERSION, notes: [] };
+  if (!data || typeof data !== 'object') return emptyStore();
+  if (!Array.isArray(data.notes)) return emptyStore();
 
+  let notes;
   if (!data.version) {
     // v1 -> current: add visible/title/displayId/pinned/monospace/timestamps.
-    return {
-      version: STORE_VERSION,
-      notes: data.notes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }))
-    };
-  }
-  if (data.version === 2) {
+    notes = data.notes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }));
+  } else if (data.version === 2) {
     // v2 -> current: backfill pinned:true so existing notes keep today's
     // always-on-top behavior unchanged. Monospace defaults to off unless
     // the record already has it set.
-    return {
-      version: STORE_VERSION,
-      notes: data.notes.map((n) => ({
-        ...n,
-        pinned: n.pinned !== undefined ? !!n.pinned : true,
-        monospace: !!n.monospace
-      }))
-    };
-  }
-  if (data.version === 3) {
+    notes = data.notes.map((n) => ({
+      ...n,
+      pinned: n.pinned !== undefined ? !!n.pinned : true,
+      monospace: !!n.monospace
+    }));
+  } else if (data.version === 3 || data.version === 4 || data.version === 5) {
     // v3 -> v4: existing notes stay proportional unless the user toggles {}.
-    return {
-      version: STORE_VERSION,
-      notes: data.notes.map((n) => ({ ...n, monospace: !!n.monospace }))
-    };
+    // v4/v5 -> v6: the workspace backfill below is the only change; spreading
+    // keeps any fields this version doesn't know about (e.g. v5 `images`).
+    notes = data.notes.map((n) => ({ ...n, monospace: !!n.monospace }));
+  } else {
+    notes = data.notes;
   }
-  return data;
+
+  // Every pre-v6 file predates workspaces, so normalizeWorkspaces drops all
+  // of its notes into a single "Default" workspace and makes it active, so an
+  // upgrading user sees exactly the notes they saw before.
+  return normalizeWorkspaces({ ...data, notes });
 }
 
 class NoteStore {
@@ -107,7 +192,7 @@ class NoteStore {
     try {
       raw = fs.readFileSync(this.filePath); // Buffer
     } catch (_) {
-      return { data: { version: STORE_VERSION, notes: [] }, migrated: false };
+      return { data: emptyStore(), migrated: false };
     }
 
     // 1) Encryption enabled: try to decrypt the file first.
@@ -156,7 +241,7 @@ class NoteStore {
     } catch (_) {}
     console.error('notes.json was corrupted, backed up to', this.backupPath);
     if (this.onCorrupted) this.onCorrupted(this.backupPath);
-    return { version: STORE_VERSION, notes: [] };
+    return emptyStore();
   }
 
   _writeNow() {
@@ -203,7 +288,12 @@ class NoteStore {
   }
 
   create(overrides = {}) {
-    const record = defaultRecord(overrides);
+    // A new note belongs to whatever workspace is on screen right now,
+    // unless the caller is explicit about it.
+    const record = defaultRecord({
+      workspaceId: this.activeWorkspaceId(),
+      ...overrides
+    });
     this.data.notes.push(record);
     this.save();
     return record;
@@ -224,6 +314,103 @@ class NoteStore {
     this.save();
     return true;
   }
+
+  // ---------- Workspaces (issue #8) ----------
+  //
+  // Workspace membership and `visible` are deliberately independent.
+  // `visible` stays the user's per-note choice *within* its workspace, so
+  // switching away and back restores exactly the notes that were open. It
+  // is never rewritten as a side effect of changing workspace. Callers
+  // decide what to render with:
+  //
+  //     shown = note.visible && note.workspaceId === activeWorkspaceId()
+
+  settings() {
+    return this.data.settings;
+  }
+
+  workspaces() {
+    return this.data.workspaces;
+  }
+
+  getWorkspace(id) {
+    return this.data.workspaces.find((w) => w.id === id) || null;
+  }
+
+  activeWorkspaceId() {
+    return this.data.settings.activeWorkspace;
+  }
+
+  notesInWorkspace(workspaceId) {
+    return this.data.notes.filter((n) => n.workspaceId === workspaceId);
+  }
+
+  setActiveWorkspace(id) {
+    if (!this.getWorkspace(id)) return null;
+    this.data.settings.activeWorkspace = id;
+    this.save();
+    return id;
+  }
+
+  createWorkspace(name) {
+    const workspace = defaultWorkspace({ name });
+    this.data.workspaces.push(workspace);
+    this.save();
+    return workspace;
+  }
+
+  renameWorkspace(id, name) {
+    const workspace = this.getWorkspace(id);
+    if (!workspace) return null;
+    const clean = sanitizeWorkspaceName(name);
+    if (!clean) return workspace; // ignore a blank rename rather than wiping the label
+    workspace.name = clean;
+    this.save();
+    return workspace;
+  }
+
+  // Deleting a workspace never deletes notes. They are reassigned to the
+  // fallback workspace. Refuses to remove the last remaining workspace so
+  // the "at least one workspace" invariant always holds.
+  // Returns { movedCount, fallbackId } on success, or null if refused.
+  removeWorkspace(id) {
+    if (this.data.workspaces.length <= 1) return null;
+    const idx = this.data.workspaces.findIndex((w) => w.id === id);
+    if (idx === -1) return null;
+
+    const remaining = this.data.workspaces.filter((w) => w.id !== id);
+    const fallback = remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0];
+
+    let movedCount = 0;
+    for (const note of this.data.notes) {
+      if (note.workspaceId === id) {
+        note.workspaceId = fallback.id;
+        movedCount++;
+      }
+    }
+
+    this.data.workspaces.splice(idx, 1);
+    if (this.data.settings.activeWorkspace === id) {
+      this.data.settings.activeWorkspace = fallback.id;
+    }
+    this.save();
+    return { movedCount, fallbackId: fallback.id };
+  }
+
+  moveNote(noteId, workspaceId) {
+    const record = this.get(noteId);
+    if (!record || !this.getWorkspace(workspaceId)) return null;
+    record.workspaceId = workspaceId;
+    record.updatedAt = Date.now();
+    this.save();
+    return record;
+  }
 }
 
-module.exports = { NoteStore, defaultRecord, STORE_VERSION };
+module.exports = {
+  NoteStore,
+  defaultRecord,
+  STORE_VERSION,
+  DEFAULT_WORKSPACE_ID,
+  sanitizeWorkspaceName
+};

--- a/store.js
+++ b/store.js
@@ -6,9 +6,15 @@ const path = require('path');
 
 const STORE_VERSION = 6;
 
-// Every install has at least one workspace and it can never be deleted, so a
-// fixed id keeps migrations and the "where do orphaned notes go" fallback
-// simple, with no lookup needed to find a guaranteed-valid destination.
+// The workspace every migrated note lands in. The id is fixed so migrations
+// have a stable target and so the "where do orphaned notes go" fallback has
+// something to prefer.
+//
+// It is NOT permanent: any workspace can be deleted as long as it is not the
+// last one, this one included. Someone who organises into "Work" and
+// "Personal" should not be stuck with an unused "Default" forever. The
+// invariant that actually holds is that at least one workspace always exists,
+// so pickFallbackWorkspace() always has a destination.
 const DEFAULT_WORKSPACE_ID = 'ws-default';
 const DEFAULT_WORKSPACE_NAME = 'Default';
 const MAX_WORKSPACE_NAME_LENGTH = 40;
@@ -65,6 +71,16 @@ function defaultRecord(overrides = {}) {
   };
 }
 
+// Where notes go when their own workspace is missing or is being removed.
+// Prefers the default workspace when it is still present, otherwise the
+// first remaining one. Callers use this to name the real destination rather
+// than assuming it is "Default", which is wrong once that workspace has been
+// renamed or deleted. Returns null only for an empty list.
+function pickFallbackWorkspace(workspaces, excludeId) {
+  const remaining = excludeId === undefined ? workspaces : workspaces.filter((w) => w.id !== excludeId);
+  return remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0] || null;
+}
+
 function emptyStore() {
   const workspace = defaultWorkspace({
     id: DEFAULT_WORKSPACE_ID,
@@ -102,7 +118,7 @@ function normalizeWorkspaces(data) {
   }
 
   const ids = new Set(workspaces.map((w) => w.id));
-  const fallbackId = ids.has(DEFAULT_WORKSPACE_ID) ? DEFAULT_WORKSPACE_ID : workspaces[0].id;
+  const fallbackId = pickFallbackWorkspace(workspaces).id;
 
   const notes = data.notes.map((n) => ({
     ...n,
@@ -369,6 +385,14 @@ class NoteStore {
     return workspace;
   }
 
+  // Where the notes of `id` would go if it were deleted. Exposed so the
+  // confirmation dialog can name the real destination instead of assuming
+  // it is called "Default". Returns null when `id` is the last workspace.
+  fallbackWorkspaceFor(id) {
+    if (this.data.workspaces.length <= 1) return null;
+    return pickFallbackWorkspace(this.data.workspaces, id);
+  }
+
   // Deleting a workspace never deletes notes. They are reassigned to the
   // fallback workspace. Refuses to remove the last remaining workspace so
   // the "at least one workspace" invariant always holds.
@@ -378,8 +402,7 @@ class NoteStore {
     const idx = this.data.workspaces.findIndex((w) => w.id === id);
     if (idx === -1) return null;
 
-    const remaining = this.data.workspaces.filter((w) => w.id !== id);
-    const fallback = remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0];
+    const fallback = pickFallbackWorkspace(this.data.workspaces, id);
 
     let movedCount = 0;
     for (const note of this.data.notes) {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,0 +1,287 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { NoteStore, STORE_VERSION, DEFAULT_WORKSPACE_ID } = require('../store');
+
+const tempDirs = [];
+const stores = [];
+
+// NoteStore reads and writes notes.json at construction, so each test gets its
+// own directory. Passing `seed` writes a store file first, which is how the
+// migration paths are exercised.
+function storeDir(seed) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-notes-test-'));
+  tempDirs.push(dir);
+  if (seed !== undefined) {
+    fs.writeFileSync(path.join(dir, 'notes.json'), JSON.stringify(seed));
+  }
+  return dir;
+}
+
+function openStore(dir) {
+  const store = new NoteStore(dir);
+  stores.push(store);
+  return store;
+}
+
+function freshStore(seed) {
+  return openStore(storeDir(seed));
+}
+
+test.after(() => {
+  // Saves are debounced, so settle any pending write before the directories
+  // go away. Otherwise the timer fires against a deleted path and the store
+  // reports a write failure long after the test that caused it has passed.
+  for (const store of stores) store.flush();
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('a fresh install starts with one default workspace', () => {
+  const store = freshStore();
+  assert.equal(store.data.version, STORE_VERSION);
+  assert.equal(store.workspaces().length, 1);
+  assert.equal(store.workspaces()[0].id, DEFAULT_WORKSPACE_ID);
+  assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
+  assert.deepEqual(store.all(), []);
+});
+
+test('migrates a v1 file, backfilling the fields it predates', () => {
+  const store = freshStore({ notes: [{ id: 'a', text: 'hello' }, { id: 'b', text: 'world' }] });
+  assert.equal(store.data.version, STORE_VERSION);
+  assert.equal(store.all().length, 2);
+  assert.equal(store.get('a').text, 'hello');
+  assert.ok(store.all().every((n) => n.visible === true));
+  assert.ok(store.all().every((n) => n.pinned === true));
+  assert.ok(store.all().every((n) => n.workspaceId === DEFAULT_WORKSPACE_ID));
+});
+
+test('migrates a v4 file without disturbing per-note state', () => {
+  const store = freshStore({
+    version: 4,
+    notes: [
+      { id: 'a', text: 'kept open', visible: true, monospace: false, color: 'blue' },
+      { id: 'b', text: 'left closed', visible: false, monospace: true, color: 'pink' }
+    ]
+  });
+  assert.equal(store.data.version, STORE_VERSION);
+  // An upgrading user must see exactly the notes they saw before, so a note
+  // the user had closed stays closed.
+  assert.equal(store.get('a').visible, true);
+  assert.equal(store.get('b').visible, false);
+  assert.equal(store.get('b').monospace, true);
+  assert.equal(store.get('b').color, 'pink');
+  assert.ok(store.all().every((n) => n.workspaceId === DEFAULT_WORKSPACE_ID));
+});
+
+test('accepts a v5 file so merge order with the images change does not matter', () => {
+  const store = freshStore({
+    version: 5,
+    notes: [{ id: 'a', text: 'has pics', visible: true, images: ['x.png', 'y.png'] }]
+  });
+  assert.equal(store.data.version, STORE_VERSION);
+  assert.deepEqual(store.get('a').images, ['x.png', 'y.png']);
+  assert.equal(store.get('a').workspaceId, DEFAULT_WORKSPACE_ID);
+});
+
+test('keeps settings keys it does not know about', () => {
+  // `settings` is the app-level container; other features will add sibling
+  // keys to it and a workspace migration must not drop them.
+  const store = freshStore({ version: 4, settings: { theme: 'dark' }, notes: [] });
+  assert.equal(store.settings().theme, 'dark');
+  assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
+});
+
+test('repairs notes and an active workspace pointing at a workspace that is gone', () => {
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: { activeWorkspace: 'ws-gone' },
+    workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'Default', createdAt: 1 }],
+    notes: [{ id: 'a', text: 'orphan', workspaceId: 'ws-vanished', visible: true }]
+  });
+  // Otherwise the note would be stranded in a workspace no dropdown lists,
+  // making it unreachable from the UI.
+  assert.equal(store.get('a').workspaceId, DEFAULT_WORKSPACE_ID);
+  assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
+});
+
+test('collapses duplicate ids, drops non-objects, and repairs a missing id', () => {
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: { activeWorkspace: DEFAULT_WORKSPACE_ID },
+    workspaces: [
+      { id: DEFAULT_WORKSPACE_ID, name: 'Default', createdAt: 1 },
+      { id: DEFAULT_WORKSPACE_ID, name: 'Default again', createdAt: 2 },
+      { id: 'ws-ok', name: 'Real', createdAt: 3 },
+      null,
+      { name: 'no id at all' }
+    ],
+    notes: [{ id: 'a', text: 'x', workspaceId: 'ws-ok' }]
+  });
+  // The genuine duplicate collapses and the first one wins. `null` is not an
+  // object so it goes. The entry missing an id is a named workspace, so it is
+  // repaired with a generated id rather than silently discarded.
+  assert.equal(store.workspaces().length, 3);
+  assert.equal(store.getWorkspace(DEFAULT_WORKSPACE_ID).name, 'Default');
+  assert.ok(store.workspaces().some((w) => w.name === 'no id at all'));
+  assert.equal(store.get('a').workspaceId, 'ws-ok');
+});
+
+test('replaces blank ids without merging distinct workspaces', () => {
+  // defaultWorkspace generates an id for a blank one, so deduping on the raw
+  // value would treat these two as the same workspace and drop the second.
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: {},
+    workspaces: [{ id: '', name: 'A' }, { id: '   ', name: 'B' }],
+    notes: []
+  });
+  assert.equal(store.workspaces().length, 2);
+  assert.notEqual(store.workspaces()[0].id, store.workspaces()[1].id);
+  assert.ok(store.workspaces().every((w) => w.id.trim().length > 0));
+  assert.ok(store.activeWorkspaceId());
+});
+
+test('a note pointing at a blank workspace id is reattached, not dropped', () => {
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: {},
+    workspaces: [{ id: '', name: 'A' }, { id: DEFAULT_WORKSPACE_ID, name: 'Default' }],
+    notes: [{ id: 'n', text: 'keep me', workspaceId: '' }]
+  });
+  assert.equal(store.all().length, 1);
+  assert.equal(store.get('n').text, 'keep me');
+  assert.ok(store.getWorkspace(store.get('n').workspaceId));
+});
+
+test('creates, renames and switches workspaces', () => {
+  const store = freshStore();
+  const workspace = store.createWorkspace('Interview Notes');
+  assert.equal(store.workspaces().length, 2);
+
+  store.renameWorkspace(workspace.id, '  Presentation 1\n');
+  assert.equal(store.getWorkspace(workspace.id).name, 'Presentation 1');
+
+  // A blank rename would wipe the label off the dropdown, so it is ignored.
+  store.renameWorkspace(workspace.id, '   ');
+  assert.equal(store.getWorkspace(workspace.id).name, 'Presentation 1');
+
+  assert.equal(store.setActiveWorkspace(workspace.id), workspace.id);
+  assert.equal(store.setActiveWorkspace('nope'), null);
+  assert.equal(store.activeWorkspaceId(), workspace.id);
+});
+
+test('new notes land in the active workspace', () => {
+  const store = freshStore();
+  const workspace = store.createWorkspace('Scratchpad');
+  store.setActiveWorkspace(workspace.id);
+  assert.equal(store.create({ text: 'in ws' }).workspaceId, workspace.id);
+});
+
+test('deleting a workspace reassigns its notes rather than deleting them', () => {
+  const store = freshStore();
+  const workspace = store.createWorkspace('Scratchpad');
+  store.setActiveWorkspace(workspace.id);
+  store.create({ text: 'one' });
+  store.create({ text: 'two' });
+
+  const result = store.removeWorkspace(workspace.id);
+  assert.equal(result.movedCount, 2);
+  assert.equal(store.all().length, 2);
+  assert.ok(store.all().every((n) => n.workspaceId === DEFAULT_WORKSPACE_ID));
+  assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
+  assert.equal(store.getWorkspace(workspace.id), null);
+});
+
+test('refuses to remove the last workspace', () => {
+  const store = freshStore();
+  assert.equal(store.fallbackWorkspaceFor(DEFAULT_WORKSPACE_ID), null);
+  assert.equal(store.removeWorkspace(DEFAULT_WORKSPACE_ID), null);
+  assert.equal(store.workspaces().length, 1);
+});
+
+test('names the workspace notes will really land in, which is not always Default', () => {
+  const store = freshStore();
+  store.renameWorkspace(DEFAULT_WORKSPACE_ID, 'Personal');
+  const work = store.createWorkspace('Work');
+  store.setActiveWorkspace(DEFAULT_WORKSPACE_ID);
+  store.create({ text: 'one' });
+  store.create({ text: 'two' });
+
+  // The confirmation dialog asks for this so it can name the destination
+  // instead of claiming the notes go to "Default".
+  assert.equal(store.fallbackWorkspaceFor(DEFAULT_WORKSPACE_ID).id, work.id);
+
+  const result = store.removeWorkspace(DEFAULT_WORKSPACE_ID);
+  assert.equal(result.fallbackId, work.id);
+  assert.equal(store.all().length, 2);
+  assert.ok(store.all().every((n) => n.workspaceId === work.id));
+  assert.equal(store.getWorkspace(DEFAULT_WORKSPACE_ID), null);
+});
+
+test('the default workspace is preferred as a fallback while it exists', () => {
+  const store = freshStore();
+  const a = store.createWorkspace('A');
+  store.createWorkspace('B');
+  assert.equal(store.fallbackWorkspaceFor(a.id).id, DEFAULT_WORKSPACE_ID);
+
+  store.renameWorkspace(DEFAULT_WORKSPACE_ID, 'Home');
+  assert.equal(store.fallbackWorkspaceFor(a.id).name, 'Home');
+});
+
+test('moves notes between workspaces and rejects unknown ids', () => {
+  const store = freshStore();
+  const workspace = store.createWorkspace('Other');
+  const note = store.create({ text: 'movable' });
+
+  assert.equal(store.moveNote(note.id, workspace.id).workspaceId, workspace.id);
+  assert.equal(store.moveNote(note.id, 'nope'), null);
+  assert.equal(store.moveNote('nope', workspace.id), null);
+});
+
+test('workspaces and per-note visibility survive a reload', () => {
+  const dir = storeDir();
+  const first = openStore(dir);
+  const workspace = first.createWorkspace('Persisted');
+  first.setActiveWorkspace(workspace.id);
+  first.create({ text: 'survivor', visible: false });
+  first.flush();
+
+  const second = openStore(dir);
+  assert.equal(second.activeWorkspaceId(), workspace.id);
+  assert.equal(second.notesInWorkspace(workspace.id).length, 1);
+  assert.equal(second.notesInWorkspace(workspace.id)[0].visible, false);
+  assert.equal(second.data.version, STORE_VERSION);
+});
+
+test('a malformed store file loads instead of crashing on launch', () => {
+  // Reading a field off a null entry throws, and the throw escapes the
+  // JSON.parse try block in _load, so it would surface as a crash at startup
+  // rather than the corrupt-file recovery path.
+  const malformed = [
+    { version: STORE_VERSION, settings: { activeWorkspace: DEFAULT_WORKSPACE_ID }, workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'D' }], notes: [null] },
+    { version: 4, notes: [null] },
+    { version: 2, notes: [null] },
+    { notes: [null] },
+    { version: STORE_VERSION, settings: null, workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'D' }], notes: [] },
+    { version: STORE_VERSION, settings: 'not an object', workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'D' }], notes: [] }
+  ];
+  for (const seed of malformed) {
+    assert.doesNotThrow(() => freshStore(seed));
+  }
+});
+
+test('malformed entries are dropped without taking valid notes with them', () => {
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: { activeWorkspace: DEFAULT_WORKSPACE_ID },
+    workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'D' }],
+    notes: [{ id: 'a', text: 'real' }, null, { id: 'b', text: 'also real' }, 42]
+  });
+  assert.equal(store.all().length, 2);
+  assert.equal(store.get('a').text, 'real');
+  assert.equal(store.get('b').text, 'also real');
+  assert.ok(store.all().every((n) => !!store.getWorkspace(n.workspaceId)));
+});


### PR DESCRIPTION
## Description

Adds named workspaces so notes can be grouped by context ("Interview Notes", "Presentation 1", "Scratchpad") with the active workspace deciding what is on screen.

Two design decisions worth calling out, since they shaped the rest of the change:

**Workspaces are first-class records, not a string tag on each note.** Deriving the workspace list from distinct tag values would be less code, but a workspace would vanish from the dropdown the moment its last note moved out, and renaming one would mean rewriting every note. They are stored as `{ id, name, createdAt }` with a `workspaceId` on each note instead.

**Workspace membership and `visible` are kept independent.** `visible` is the durable record of "the user wants this note open" and it drives which windows are restored at startup. If a workspace switch simply called the existing `hideNote()` / `showNote()`, it would rewrite `visible` as a side effect: leave 2 of 5 notes open, switch away, switch back, and all 5 return, quietly discarding the per-note choices on every switch. So a note is on screen only when both hold:

```
note.visible && note.workspaceId === settings.activeWorkspace
```

Switching moves windows through new `openWindowFor` / `closeWindowFor` helpers that never touch the record. `hideNote` / `showNote` remain the record-writing pair for when the user really does mean show or hide.

## Related Issue

Closes #8

## Changes Made

- `store.js`: schema v6 adds a `workspaces` list, a `workspaceId` on every note, and a `settings` container for app-level state. Adds workspace CRUD plus `moveNote`, `notesInWorkspace`, and `setActiveWorkspace`.
- `store.js`: `normalizeWorkspaces()` runs on every load, not just on migration, so a hand-edited or partially written file cannot strand notes in a workspace that no longer exists. It also collapses duplicate ids and drops malformed entries.
- `main.js`: splits window operations from record writes, adds `applyActiveWorkspace()` (which doubles as the startup path), and scopes hide-all and click-through-all to the active workspace.
- `main.js`: tray gains a `Switch Workspace` submenu with radio items and live note counts. The `Notes` submenu is now scoped to the active workspace.
- `manager.js` / `manager-preload.js`: IPC for workspace create, rename, delete, switch, and move-note. `manager:list` and the change notification now send one snapshot of notes plus workspaces, so the renderer can never render notes against a stale workspace list.
- `manager.html` / `manager-renderer.js`: workspace bar with a dropdown and create, rename, and delete controls, a per-card control for moving a note between workspaces, and a list filtered to the active workspace.

A few notes on the details:

- Deleting a workspace reassigns its notes to Default behind a confirmation that states the count, rather than deleting them. The last remaining workspace cannot be deleted.
- The migration accepts either v4 or v5 as its source, so this is independent of merge order with the images work in #9. Every existing note lands in a `Default` workspace, so an upgrading user sees exactly what they saw before.
- The `settings` container is deliberately generic. #2 needs somewhere to persist a theme preference and #5 needs somewhere to persist custom keybindings, and the store previously had nowhere to put anything that is not per-note. Unknown keys in `settings` are preserved across migration.
- Create and rename use an inline field in the manager window rather than a native dialog, because Electron disables `window.prompt()`.
- Windows for inactive workspaces are hidden rather than destroyed, which keeps switching instant and preserves renderer state. They are created lazily, so the count is bounded by the workspaces actually visited in a session.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [x] Tested on Linux (if applicable)

Tested on Linux (Ubuntu, GNOME on Wayland, Electron 33.4.11). No platform-specific code was added, so nothing in this change branches on the OS, but I do not have macOS or Windows hardware to confirm on.

Alongside the manual pass I ran two throwaway harnesses while developing:

- The store layer against every migration path (v1, v2, v3, v4, and v5 sources), workspace CRUD, the "deleting a workspace never deletes notes" rule, orphan and duplicate repair, and a round trip through disk with encryption on. 55 assertions.
- The manager window loaded for real through its own preload and IPC, asserting on the resulting DOM: dropdown contents and counts, list scoping, the inline name form, a create round trip, and that a workspace switch leaves every `visible` flag untouched. 22 assertions.

I also confirmed against a real encrypted v4 store that the migration keeps the existing note and that the pre-migration snapshot is written.

**Steps to reproduce / verify:**

1. Open Notes Manager with `Cmd/Ctrl+Shift+M`. The existing notes are in a `Default` workspace.
2. Click `+` in the workspace bar, name it `Interview Notes`, save. The Default notes leave the screen and the list is empty.
3. Create two notes and type something in each.
4. Close one of them with its X button, leaving the other open.
5. Switch back to `Default` in the dropdown. The interview notes go, the Default notes return.
6. Switch to `Interview Notes` again. Only the note left open comes back. The closed one stays closed.
7. Open the tray menu and confirm `Switch Workspace` shows both workspaces with note counts and a radio mark on the active one.
8. Use the small dropdown on a card to move a note to the other workspace, and confirm its window follows.
9. Delete a non-empty workspace and confirm the dialog says the notes will be moved rather than deleted, then confirm they arrive in Default.

## Screenshots / Recordings (if applicable)

Screen recording of the flow above, originally posted on the issue: https://github.com/navyabijoy/invisible-notes/issues/8#issuecomment-5484576255

https://github.com/user-attachments/assets/59c49e90-460e-4a8b-a4b2-28dc343adf30

One note on recording this feature: `setContentProtection` is macOS and Windows only, so on those platforms the notes are excluded from screen capture by design and would not appear in a recording at all. On Linux it is a no-op, which is why the notes are visible in this video.

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused, this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`

