### PR TITLE
fix(platform): re-apply content protection after sleep on Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -186,6 +186,20 @@ function reconcileOpenWindowsToDisplays() {
   }
 }
 
+// On Windows, SetWindowDisplayAffinity can be silently dropped after sleep,
+// screen lock, or display topology changes. Re-apply to every open note window.
+function reapplyContentProtectionToOpenWindows() {
+  if (!platform.isWindows) return;
+  for (const win of noteWindows.values()) {
+    applyContentProtection(win);
+  }
+}
+
+function reconcileOpenWindowsAfterSystemChange() {
+  reconcileOpenWindowsToDisplays();
+  reapplyContentProtectionToOpenWindows();
+}
+
 // ---------- IPC from renderer ----------
 ipcMain.on('note:update', (e, payload) => {
   if (!payload || typeof payload.id !== 'string') return;
@@ -335,14 +349,14 @@ if (!gotLock) {
       openManager: () => manager.openManagerWindow()
     });
 
-    screen.on('display-added', reconcileOpenWindowsToDisplays);
-    screen.on('display-removed', reconcileOpenWindowsToDisplays);
-    screen.on('display-metrics-changed', reconcileOpenWindowsToDisplays);
+    screen.on('display-added', reconcileOpenWindowsAfterSystemChange);
+    screen.on('display-removed', reconcileOpenWindowsAfterSystemChange);
+    screen.on('display-metrics-changed', reconcileOpenWindowsAfterSystemChange);
 
     // Waking from sleep can silently change the connected-display set before
     // the OS fires its own display events — re-check note positions either way.
-    powerMonitor.on('resume', reconcileOpenWindowsToDisplays);
-    powerMonitor.on('unlock-screen', reconcileOpenWindowsToDisplays);
+    powerMonitor.on('resume', reconcileOpenWindowsAfterSystemChange);
+    powerMonitor.on('unlock-screen', reconcileOpenWindowsAfterSystemChange);
   });
 
   app.on('before-quit', () => {

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -9,9 +9,12 @@ const { clampToVisibleDisplay } = require('./displayUtils');
 
 // Apply (or re-apply) screen-capture exclusion on a window.
 // On Windows, some Electron versions clear the SetWindowDisplayAffinity flag
-// when the window is hidden via win.hide(). This helper is called:
+// when the window is hidden via win.hide(), or when the system sleeps, locks,
+// or reinitializes the display. This helper is called:
 //   1. At window creation (inside 'ready-to-show', so the HWND fully exists)
 //   2. Every time a hidden note is shown again (see main.js showNote)
+//   3. On window show/restore events (Windows only, see createNoteWindow)
+//   4. After sleep/unlock/display changes (see main.js reconcileOpenWindowsAfterSystemChange)
 function applyContentProtection(win) {
   if (!win || win.isDestroyed()) return;
   win.setContentProtection(true);
@@ -42,6 +45,13 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
   });
 
   platform.setPinned(win, record.pinned !== false);
+
+  // Defense-in-depth: re-apply capture exclusion whenever Windows shows or
+  // restores a note window (e.g. after minimize/restore or OS-driven show).
+  if (platform.isWindows) {
+    win.on('show', () => applyContentProtection(win));
+    win.on('restore', () => applyContentProtection(win));
+  }
 
   win.loadFile('note.html', { query: { id: record.id } });
 


### PR DESCRIPTION
## Summary

Fixes #4. On Windows, `SetWindowDisplayAffinity` (used by `setContentProtection`) can be silently dropped after sleep, screen lock, or display changes — causing notes to appear in screen shares. This PR re-applies capture exclusion at the lifecycle points where Windows is known to lose the flag.

## Changes

### `main.js`
- **`reapplyContentProtectionToOpenWindows()`** — loops all open note windows and calls `applyContentProtection()` (Windows only).
- **`reconcileOpenWindowsAfterSystemChange()`** — runs existing display repositioning first, then re-applies protection (order matters: `setBounds` must happen before re-protecting).
- **Event hooks** — `display-added`, `display-removed`, `display-metrics-changed`, `resume`, and `unlock-screen` now call the combined reconciler instead of display-only reconciliation.

### `noteWindow.js`
- **Windows `show` / `restore` listeners** — re-apply protection whenever a note window becomes visible or is restored from minimized (defense-in-depth alongside the existing `showNote()` workaround for hide/show).

## Why

The app already re-applied protection when a hidden note was shown again (`showNote`). It did not handle sleep/wake, lock/unlock, display topology changes, or minimize/restore — all cases where Windows/DWM can reset the affinity flag without notifying the app.

## Test plan

- [ ] macOS smoke test — notes launch and behave normally (no behavior change expected)
- [ ] Windows: create note, confirm invisible in Snipping Tool / screen share
- [ ] Windows: sleep/wake — note still invisible in capture
- [ ] Windows: lock/unlock (Win+L) — note still invisible in capture
- [ ] Windows: hide/show via ✕ and Ctrl+Shift+H — still invisible (regression check)

