### PR TITLE
fix(shortcuts): scope shortcuts to app windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
 - **Quit:** tray icon → Quit
 
-If a global shortcut above doesn't register (another app already uses it), Ghost Notes logs a warning and keeps running — that shortcut just won't fire; everything is still reachable from the tray menu and Notes Manager.
+Keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system.
 
 Notes (text, position, size, color, opacity, open/hidden state) auto-save and reappear on next launch. Data lives in a single local JSON file in the OS app-data folder — never uploaded anywhere.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
 - **Quit:** tray icon → Quit
 
-The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The four-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden.
+The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden.
 
 Notes (text, position, size, color, opacity, open/hidden state) auto-save and reappear on next launch. Data lives in a single local JSON file in the OS app-data folder — never uploaded anywhere.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 ## Usage
 
 - **New note:** `Cmd/Ctrl+Shift+N` (or tray icon → New Note, or the ＋ on a note)
+- **New note when all windows are hidden:** `Cmd/Ctrl+Alt+Shift+N` (global recovery shortcut)
 - **Notes Manager:** `Cmd/Ctrl+Shift+M` (or tray icon → Notes Manager…) — see every note you've ever created, open/hide/rename/delete it
 - **Hide / show all notes:** `Cmd/Ctrl+Shift+H`
 - **Toggle click-through (all notes):** `Cmd/Ctrl+Shift+G`
@@ -38,7 +39,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
 - **Quit:** tray icon → Quit
 
-Keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system.
+The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The four-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden.
 
 Notes (text, position, size, color, opacity, open/hidden state) auto-save and reappear on next launch. Data lives in a single local JSON file in the OS app-data folder — never uploaded anywhere.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -603,7 +603,7 @@
       <div class="shortcuts-inner">
         <div class="shortcuts-text reveal">
           <h2>Keyboard<br>shortcuts</h2>
-          <p>Designed to stay out of your way. Every action you need, bound to a global shortcut.</p>
+          <p>Designed to stay out of your way. Shortcuts activate only while a Ghost Notes window has focus.</p>
         </div>
 
         <div class="shortcut-table reveal" role="table">

--- a/docs/index.html
+++ b/docs/index.html
@@ -603,7 +603,7 @@
       <div class="shortcuts-inner">
         <div class="shortcuts-text reveal">
           <h2>Keyboard<br>shortcuts</h2>
-          <p>Designed to stay out of your way. Shortcuts activate only while a Ghost Notes window has focus.</p>
+          <p>Standard shortcuts activate only while a Ghost Notes window has focus. A separate global recovery shortcut creates a note when every window is hidden.</p>
         </div>
 
         <div class="shortcut-table reveal" role="table">

--- a/docs/index.html
+++ b/docs/index.html
@@ -618,6 +618,11 @@
             <div role="cell"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>N</kbd></div>
           </div>
           <div class="shortcut-row shortcut-body" role="row">
+            <div role="cell">New note (global recovery)</div>
+            <div role="cell"><kbd>&#8984;</kbd><kbd>Option</kbd><kbd>&#8679;</kbd><kbd>N</kbd></div>
+            <div role="cell"><kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>N</kbd></div>
+          </div>
+          <div class="shortcut-row shortcut-body" role="row">
             <div role="cell">Notes Manager</div>
             <div role="cell"><kbd>&#8984;</kbd><kbd>&#8679;</kbd><kbd>M</kbd></div>
             <div role="cell"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>M</kbd></div>

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const { NoteStore } = require('./store');
 const platform = require('./platform');
 const { createNoteWindow, applyContentProtection } = require('./noteWindow');
 const { clampToVisibleDisplay, displayIdForPoint } = require('./displayUtils');
-const { registerShortcuts, unregisterAll } = require('./shortcuts');
+const { registerShortcuts } = require('./shortcuts');
 const { createManagerModule } = require('./manager');
 
 // Show plain-language notices only — never a raw stack trace to the user.
@@ -74,7 +74,9 @@ function createManager() {
       hideNote: (id) => hideNote(id),
       deleteNoteRecord: (id) => deleteNoteRecord(id),
       renameNote: (id, title) => renameNote(id, title),
-      createNote: () => createNoteNearCursor()
+      createNote: () => createNoteNearCursor(),
+      toggleHideAll: () => toggleHideAll(),
+      toggleGhostAll: () => toggleGhostAll()
     }
   });
 }
@@ -93,6 +95,12 @@ function openNoteWindow(record) {
     onClosed: () => {
       noteWindows.delete(record.id);
     }
+  });
+  registerShortcuts(win, {
+    newNote: () => createNoteNearCursor(),
+    toggleHideAll: () => toggleHideAll(),
+    toggleGhostAll: () => toggleGhostAll(),
+    openManager: () => manager.openManagerWindow()
   });
   noteWindows.set(record.id, win);
   return win;
@@ -328,13 +336,6 @@ if (!gotLock) {
       }
     }
 
-    registerShortcuts({
-      newNote: () => createNoteNearCursor(),
-      toggleHideAll: () => toggleHideAll(),
-      toggleGhostAll: () => toggleGhostAll(),
-      openManager: () => manager.openManagerWindow()
-    });
-
     screen.on('display-added', reconcileOpenWindowsToDisplays);
     screen.on('display-removed', reconcileOpenWindowsToDisplays);
     screen.on('display-metrics-changed', reconcileOpenWindowsToDisplays);
@@ -347,10 +348,6 @@ if (!gotLock) {
 
   app.on('before-quit', () => {
     store.flush();
-  });
-
-  app.on('will-quit', () => {
-    unregisterAll();
   });
 
   // Keep running with no visible windows (tray app).

--- a/main.js
+++ b/main.js
@@ -1,10 +1,25 @@
-const { app, ipcMain, screen, Tray, Menu, nativeImage, dialog, powerMonitor, safeStorage } = require('electron');
+const {
+  app,
+  ipcMain,
+  screen,
+  Tray,
+  Menu,
+  nativeImage,
+  dialog,
+  powerMonitor,
+  safeStorage,
+  globalShortcut
+} = require('electron');
 const path = require('path');
 const { NoteStore } = require('./store');
 const platform = require('./platform');
 const { createNoteWindow, applyContentProtection } = require('./noteWindow');
 const { clampToVisibleDisplay, displayIdForPoint } = require('./displayUtils');
-const { registerShortcuts } = require('./shortcuts');
+const {
+  registerShortcuts,
+  registerFallbackShortcut,
+  unregisterFallbackShortcut
+} = require('./shortcuts');
 const { createManagerModule } = require('./manager');
 
 // Show plain-language notices only — never a raw stack trace to the user.
@@ -326,6 +341,7 @@ if (!gotLock) {
     manager = createManager();
 
     setupTray();
+    registerFallbackShortcut(globalShortcut, () => createNoteNearCursor());
 
     const records = store.all();
     if (records.length === 0) {
@@ -348,6 +364,10 @@ if (!gotLock) {
 
   app.on('before-quit', () => {
     store.flush();
+  });
+
+  app.on('will-quit', () => {
+    unregisterFallbackShortcut(globalShortcut);
   });
 
   // Keep running with no visible windows (tray app).

--- a/manager.js
+++ b/manager.js
@@ -4,6 +4,7 @@
 // touches the store directly — main.js stays the single source of truth.
 const path = require('path');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { registerShortcuts } = require('./shortcuts');
 
 const MAX_TITLE_LENGTH = 80;
 
@@ -41,6 +42,12 @@ function createManagerModule({ store, actions }) {
       }
     });
     win.setMenuBarVisibility(false);
+    registerShortcuts(win, {
+      newNote: actions.createNote,
+      toggleHideAll: actions.toggleHideAll,
+      toggleGhostAll: actions.toggleGhostAll,
+      openManager: openManagerWindow
+    });
     win.loadFile('manager.html');
     win.once('ready-to-show', () => win.show());
     win.on('closed', () => {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Ghost Notes: translucent sticky notes that stay invisible to screen sharing and recording.",
   "main": "main.js",
   "scripts": {
+    "test": "node --test",
     "start": "electron .",
     "dist": "electron-builder",
     "dist:mac": "electron-builder --mac",

--- a/platform.js
+++ b/platform.js
@@ -10,6 +10,13 @@ function hideDockIconIfMac(app) {
   if (isMac && app.dock) app.dock.hide();
 }
 
+// Electron reports Command and Control separately in before-input-event.
+// Treat only the platform's primary shortcut modifier as CmdOrCtrl so an
+// additional modifier does not accidentally trigger an app shortcut.
+function isCommandOrControlPressed(input) {
+  return isMac ? !!input.meta && !input.control : !!input.control && !input.meta;
+}
+
 // Pin/unpin a note window. Pinned = always-on-top, stays above whatever
 // app you switch to. Unpinned = a normal window that other apps can cover
 // when they're brought to the front, on both macOS and Windows.
@@ -48,6 +55,7 @@ module.exports = {
   isMac,
   isWindows,
   hideDockIconIfMac,
+  isCommandOrControlPressed,
   setPinned,
   captureExclusionCaveat
 };

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -10,6 +10,8 @@ const BINDINGS = {
   openManager: 'CommandOrControl+Shift+M'
 };
 
+const FALLBACK_BINDING = 'CommandOrControl+Alt+Shift+N';
+
 const ACTION_BY_KEY = {
   n: 'newNote',
   h: 'toggleHideAll',
@@ -33,4 +35,23 @@ function registerShortcuts(win, actions) {
   });
 }
 
-module.exports = { registerShortcuts, shortcutNameForInput, BINDINGS };
+function registerFallbackShortcut(globalShortcut, handler) {
+  const registered = globalShortcut.register(FALLBACK_BINDING, handler);
+  if (!registered) {
+    console.warn(`Fallback shortcut ${FALLBACK_BINDING} could not be registered — likely in use by another app.`);
+  }
+  return registered;
+}
+
+function unregisterFallbackShortcut(globalShortcut) {
+  globalShortcut.unregister(FALLBACK_BINDING);
+}
+
+module.exports = {
+  registerShortcuts,
+  registerFallbackShortcut,
+  unregisterFallbackShortcut,
+  shortcutNameForInput,
+  BINDINGS,
+  FALLBACK_BINDING
+};

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -19,9 +19,14 @@ const ACTION_BY_KEY = {
   m: 'openManager'
 };
 
+const ACTION_BY_CODE = Object.fromEntries(
+  Object.entries(ACTION_BY_KEY).map(([key, action]) => [`Key${key.toUpperCase()}`, action])
+);
+
 function shortcutNameForInput(input) {
   if (!input || input.type !== 'keyDown' || input.isAutoRepeat) return null;
   if (!platform.isCommandOrControlPressed(input) || !input.shift || input.alt) return null;
+  if (input.code) return ACTION_BY_CODE[input.code] || null;
   return ACTION_BY_KEY[String(input.key || '').toLowerCase()] || null;
 }
 

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -1,9 +1,7 @@
-// Global shortcuts. Kept in one place so accelerators are easy to audit
-// for conflicts with common OS/app shortcuts (Cmd/Ctrl+Shift+N and +H are
-// used by some browsers for private-window/history — Shift is included
-// deliberately to reduce collisions, and registration failure is silent
-// per Electron's design, so we log it instead of assuming success).
-const { globalShortcut } = require('electron');
+// App-scoped shortcuts. Listening on a Ghost Notes window's webContents keeps
+// these bindings inactive while another app has focus, so common shortcuts
+// such as Cmd+Shift+N remain available to browsers and IDEs.
+const platform = require('./platform');
 
 const BINDINGS = {
   newNote: 'CommandOrControl+Shift+N',
@@ -12,17 +10,27 @@ const BINDINGS = {
   openManager: 'CommandOrControl+Shift+M'
 };
 
-function registerShortcuts(actions) {
-  for (const [name, accelerator] of Object.entries(BINDINGS)) {
-    const handler = actions[name];
-    if (!handler) continue;
-    const ok = globalShortcut.register(accelerator, handler);
-    if (!ok) console.warn(`Shortcut ${accelerator} (${name}) could not be registered — likely in use by another app.`);
-  }
+const ACTION_BY_KEY = {
+  n: 'newNote',
+  h: 'toggleHideAll',
+  g: 'toggleGhostAll',
+  m: 'openManager'
+};
+
+function shortcutNameForInput(input) {
+  if (!input || input.type !== 'keyDown' || input.isAutoRepeat) return null;
+  if (!platform.isCommandOrControlPressed(input) || !input.shift || input.alt) return null;
+  return ACTION_BY_KEY[String(input.key || '').toLowerCase()] || null;
 }
 
-function unregisterAll() {
-  globalShortcut.unregisterAll();
+function registerShortcuts(win, actions) {
+  win.webContents.on('before-input-event', (event, input) => {
+    const name = shortcutNameForInput(input);
+    const handler = name && actions[name];
+    if (!handler) return;
+    event.preventDefault();
+    handler();
+  });
 }
 
-module.exports = { registerShortcuts, unregisterAll, BINDINGS };
+module.exports = { registerShortcuts, shortcutNameForInput, BINDINGS };

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+
+const platform = require('../platform');
+const { registerShortcuts, shortcutNameForInput } = require('../shortcuts');
+
+function shortcutInput(key, overrides = {}) {
+  return {
+    type: 'keyDown',
+    key,
+    shift: true,
+    alt: false,
+    control: !platform.isMac,
+    meta: platform.isMac,
+    isAutoRepeat: false,
+    ...overrides
+  };
+}
+
+test('recognizes app shortcuts with the platform modifier', () => {
+  assert.equal(shortcutNameForInput(shortcutInput('N')), 'newNote');
+  assert.equal(shortcutNameForInput(shortcutInput('h')), 'toggleHideAll');
+  assert.equal(shortcutNameForInput(shortcutInput('G')), 'toggleGhostAll');
+  assert.equal(shortcutNameForInput(shortcutInput('m')), 'openManager');
+});
+
+test('ignores incomplete, modified, repeated, and key-up input', () => {
+  assert.equal(shortcutNameForInput(shortcutInput('n', { shift: false })), null);
+  assert.equal(shortcutNameForInput(shortcutInput('n', { alt: true })), null);
+  assert.equal(shortcutNameForInput(shortcutInput('n', platform.isMac ? { control: true } : { meta: true })), null);
+  assert.equal(shortcutNameForInput(shortcutInput('n', { isAutoRepeat: true })), null);
+  assert.equal(shortcutNameForInput(shortcutInput('n', { type: 'keyUp' })), null);
+});
+
+test('handles shortcuts only through the registered Ghost Notes window', () => {
+  const webContents = new EventEmitter();
+  let newNotes = 0;
+  registerShortcuts({ webContents }, { newNote: () => newNotes++ });
+
+  let prevented = false;
+  webContents.emit(
+    'before-input-event',
+    { preventDefault: () => { prevented = true; } },
+    shortcutInput('n')
+  );
+
+  assert.equal(newNotes, 1);
+  assert.equal(prevented, true);
+});

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -3,7 +3,13 @@ const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 
 const platform = require('../platform');
-const { registerShortcuts, shortcutNameForInput } = require('../shortcuts');
+const {
+  registerShortcuts,
+  registerFallbackShortcut,
+  unregisterFallbackShortcut,
+  shortcutNameForInput,
+  FALLBACK_BINDING
+} = require('../shortcuts');
 
 function shortcutInput(key, overrides = {}) {
   return {
@@ -47,4 +53,30 @@ test('handles shortcuts only through the registered Ghost Notes window', () => {
 
   assert.equal(newNotes, 1);
   assert.equal(prevented, true);
+});
+
+test('registers and unregisters the global recovery shortcut', () => {
+  let registeredBinding = null;
+  let registeredHandler = null;
+  let unregisteredBinding = null;
+  const globalShortcut = {
+    register: (binding, handler) => {
+      registeredBinding = binding;
+      registeredHandler = handler;
+      return true;
+    },
+    unregister: (binding) => {
+      unregisteredBinding = binding;
+    }
+  };
+  let newNotes = 0;
+
+  assert.equal(registerFallbackShortcut(globalShortcut, () => newNotes++), true);
+  assert.equal(registeredBinding, 'CommandOrControl+Alt+Shift+N');
+  assert.equal(registeredBinding, FALLBACK_BINDING);
+  registeredHandler();
+  assert.equal(newNotes, 1);
+
+  unregisterFallbackShortcut(globalShortcut);
+  assert.equal(unregisteredBinding, FALLBACK_BINDING);
 });

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -15,6 +15,7 @@ function shortcutInput(key, overrides = {}) {
   return {
     type: 'keyDown',
     key,
+    code: `Key${key.toUpperCase()}`,
     shift: true,
     alt: false,
     control: !platform.isMac,
@@ -29,6 +30,12 @@ test('recognizes app shortcuts with the platform modifier', () => {
   assert.equal(shortcutNameForInput(shortcutInput('h')), 'toggleHideAll');
   assert.equal(shortcutNameForInput(shortcutInput('G')), 'toggleGhostAll');
   assert.equal(shortcutNameForInput(shortcutInput('m')), 'openManager');
+});
+
+test('uses physical key codes across keyboard layouts and falls back when unavailable', () => {
+  assert.equal(shortcutNameForInput(shortcutInput('т', { code: 'KeyN' })), 'newNote');
+  assert.equal(shortcutNameForInput(shortcutInput('n', { code: 'KeyQ' })), null);
+  assert.equal(shortcutNameForInput(shortcutInput('n', { code: '' })), 'newNote');
 });
 
 test('ignores incomplete, modified, repeated, and key-up input', () => {

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -72,7 +72,6 @@ test('registers and unregisters the global recovery shortcut', () => {
   let newNotes = 0;
 
   assert.equal(registerFallbackShortcut(globalShortcut, () => newNotes++), true);
-  assert.equal(registeredBinding, 'CommandOrControl+Alt+Shift+N');
   assert.equal(registeredBinding, FALLBACK_BINDING);
   registeredHandler();
   assert.equal(newNotes, 1);


### PR DESCRIPTION
## Description

Scopes the standard Ghost Notes keyboard shortcuts to its own note and manager windows. This prevents Cmd/Ctrl+Shift+N and the other common bindings from overriding shortcuts in browsers, IDEs, and other applications while Ghost Notes is unfocused.

It also provides one deliberately uncommon global recovery shortcut—Cmd/Ctrl+Alt+Shift+N—so users can create a note when every Ghost Notes window is hidden.

## Related Issue

Closes #17

## Changes Made

- Replace the original global shortcuts with window-scoped input handling for note and manager windows.
- Preserve the existing Cmd/Ctrl+Shift+N, H, G, and M bindings while a Ghost Notes window is focused.
- Add Cmd/Ctrl+Alt+Shift+N as the sole global recovery binding, with startup registration and quit cleanup.
- Add regression tests and update shortcut documentation for both behaviors.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (if applicable)

All four automated shortcut tests pass on Windows. Manual macOS verification is still recommended because the reported conflict uses the Command key.

**Steps to reproduce / verify:**
1. Run `npm test` and confirm all shortcut tests pass.
2. Focus a Ghost Notes window and confirm Cmd/Ctrl+Shift+N, H, G, and M trigger their documented actions.
3. Focus a browser or IDE and confirm those standard combinations remain available to that application.
4. Hide or close every Ghost Notes window, press Cmd/Ctrl+Alt+Shift+N, and confirm a new note appears.

## Screenshots / Recordings (if applicable)

Not applicable; this change has no visual UI impact.

## Checklist

- [ ] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`
