### PR TITLE
feat(shortcuts): add in-app keyboard shortcut legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Click-through mode:** the ghost icon (👻) in the hover bar — clicks pass through to whatever is behind the note; hover the bar to interact again
 - **Close a note:** ✕ in the hover bar — this **hides** the note, it does not delete it. The note stays in the Notes Manager and can be reopened any time.
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
+- **Keyboard shortcuts list:** tray icon → Keyboard Shortcuts…, or the **?** button in the Notes Manager — every active shortcut, written the way your platform writes it
 - **Quit:** tray icon → Quit
 
-The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden.
+The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden. You never have to come back here to look any of this up — the in-app list under **Keyboard Shortcuts…** shows the same thing.
 
 Notes (text, position, size, color, opacity, open/hidden state) auto-save and reappear on next launch. Data lives in a single local JSON file in the OS app-data folder — never uploaded anywhere.
 

--- a/main.js
+++ b/main.js
@@ -18,7 +18,8 @@ const { clampToVisibleDisplay, displayIdForPoint } = require('./displayUtils');
 const {
   registerShortcuts,
   registerFallbackShortcut,
-  unregisterFallbackShortcut
+  unregisterFallbackShortcut,
+  getShortcuts
 } = require('./shortcuts');
 const { createManagerModule } = require('./manager');
 
@@ -286,12 +287,21 @@ function buildNotesSubmenu() {
 function updateTrayMenu() {
   if (!tray) return;
   const caveat = platform.captureExclusionCaveat();
+  // Accelerators come from the shortcut definitions rather than being spelled
+  // out again here, so the tray can never advertise a binding the app has
+  // stopped answering to.
+  const accelerator = Object.fromEntries(getShortcuts().map((s) => [s.id, s.accelerator]));
   const menu = Menu.buildFromTemplate([
-    { label: 'New Note', accelerator: 'CmdOrCtrl+Shift+N', click: () => createNoteNearCursor() },
-    { label: 'Notes Manager…', accelerator: 'CmdOrCtrl+Shift+M', click: () => manager.openManagerWindow() },
+    { label: 'New Note', accelerator: accelerator.newNote, click: () => createNoteNearCursor() },
+    { label: 'Notes Manager…', accelerator: accelerator.openManager, click: () => manager.openManagerWindow() },
     { label: 'Notes', submenu: buildNotesSubmenu() },
-    { label: 'Hide/Show All', accelerator: 'CmdOrCtrl+Shift+H', click: () => toggleHideAll() },
-    { label: 'Toggle Click-Through (all)', accelerator: 'CmdOrCtrl+Shift+G', click: () => toggleGhostAll() },
+    { label: 'Hide/Show All', accelerator: accelerator.toggleHideAll, click: () => toggleHideAll() },
+    { label: 'Toggle Click-Through (all)', accelerator: accelerator.toggleGhostAll, click: () => toggleGhostAll() },
+    { type: 'separator' },
+    {
+      label: 'Keyboard Shortcuts…',
+      click: () => manager.openManagerWindow({ showShortcuts: true })
+    },
     { type: 'separator' },
     { label: 'Notes are invisible to screen sharing ✓', enabled: false },
     ...(caveat ? [{ label: caveat, enabled: false }] : []),

--- a/manager-preload.js
+++ b/manager-preload.js
@@ -8,5 +8,7 @@ contextBridge.exposeInMainWorld('manager', {
   rename: (id, title) => ipcRenderer.send('manager:rename', { id, title }),
   newNote: () => ipcRenderer.send('manager:new'),
   onChanged: (cb) => ipcRenderer.on('manager:notesChanged', (e, notes) => cb(notes)),
-  version: () => ipcRenderer.invoke('manager:version')
+  version: () => ipcRenderer.invoke('manager:version'),
+  shortcuts: () => ipcRenderer.invoke('manager:shortcuts'),
+  onShowShortcuts: (cb) => ipcRenderer.on('manager:showShortcuts', () => cb())
 });

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -19,6 +19,7 @@ const searchEl = document.getElementById('search');
 
 let notes = [];
 let query = '';
+let shortcuts = [];
 
 function label(note) {
   return (note.title || '').trim();
@@ -140,3 +141,101 @@ window.manager.list().then((initial) => {
 window.manager.version().then((v) => {
   document.getElementById('version').textContent = 'Ghost Notes v' + v;
 });
+
+// ─── Shortcut legend ──────────────────────────────────────
+// Read-only for now (issue #20). The rows come from the shortcut definitions
+// in the main process, already formatted for this platform, so nothing here
+// needs to know how an accelerator is spelled — when issue #5 lands custom
+// bindings, this list reflects them without changes.
+const shortcutsEl = document.getElementById('shortcuts');
+const shortcutsBodyEl = document.getElementById('shortcutsBody');
+
+const SCOPE_SECTIONS = [
+  {
+    scope: 'app',
+    title: 'In Ghost Notes',
+    note: 'Active while a note or this window has focus, so the same keys stay free in your browser and editor.'
+  },
+  {
+    scope: 'global',
+    title: 'Anywhere',
+    note: 'Registered system-wide, so you can always reach a new note even when every Ghost Notes window is hidden.'
+  }
+];
+
+function shortcutRow(shortcut) {
+  const row = document.createElement('div');
+  row.className = 'sc-row';
+
+  const text = document.createElement('div');
+  text.className = 'sc-text';
+
+  const labelEl = document.createElement('div');
+  labelEl.className = 'sc-label';
+  labelEl.textContent = shortcut.label;
+
+  const descEl = document.createElement('div');
+  descEl.className = 'sc-desc';
+  descEl.textContent = shortcut.description;
+
+  text.appendChild(labelEl);
+  text.appendChild(descEl);
+
+  const keys = document.createElement('kbd');
+  keys.className = 'sc-keys';
+  keys.textContent = shortcut.display;
+
+  row.appendChild(text);
+  row.appendChild(keys);
+  return row;
+}
+
+function renderShortcuts(shortcuts) {
+  shortcutsBodyEl.innerHTML = '';
+  for (const section of SCOPE_SECTIONS) {
+    const items = shortcuts.filter((s) => s.scope === section.scope);
+    if (items.length === 0) continue;
+
+    const group = document.createElement('div');
+    group.className = 'sc-group';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'sc-group-title';
+    titleEl.textContent = section.title;
+
+    const noteEl = document.createElement('div');
+    noteEl.className = 'sc-group-note';
+    noteEl.textContent = section.note;
+
+    group.appendChild(titleEl);
+    group.appendChild(noteEl);
+    for (const shortcut of items) group.appendChild(shortcutRow(shortcut));
+
+    shortcutsBodyEl.appendChild(group);
+  }
+}
+
+// Loaded once at startup; the definitions cannot change while the app runs.
+const shortcutsReady = window.manager.shortcuts().then((list) => {
+  shortcuts = list;
+  renderShortcuts(shortcuts);
+});
+
+async function openShortcuts() {
+  await shortcutsReady;
+  shortcutsEl.hidden = false;
+}
+
+function closeShortcuts() {
+  shortcutsEl.hidden = true;
+}
+
+document.getElementById('shortcutsBtn').addEventListener('click', openShortcuts);
+document.getElementById('shortcutsClose').addEventListener('click', closeShortcuts);
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && !shortcutsEl.hidden) closeShortcuts();
+});
+
+// Opened straight onto the legend from the tray's "Keyboard Shortcuts…" item.
+window.manager.onShowShortcuts(openShortcuts);

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -244,17 +244,34 @@ const shortcutsReady = window.manager.shortcuts().then((list) => {
   render();
 });
 
+// The legend covers the whole window, so it behaves as a modal. aria-modal
+// tells assistive tech to ignore what is behind it but does nothing about the
+// tab order, so the rest of the UI is marked inert while the panel is open.
+// Focus moves into the panel and returns to wherever it came from on close —
+// without the restore, Escape would leave focus on a now-hidden button.
+const shortcutsCloseEl = document.getElementById('shortcutsClose');
+const behindTheSheet = [document.querySelector('.toolbar'), listEl, document.getElementById('version')];
+let focusBeforeShortcuts = null;
+
 async function openShortcuts() {
   await shortcutsReady;
+  if (!shortcutsEl.hidden) return;
+  focusBeforeShortcuts = document.activeElement;
   shortcutsEl.hidden = false;
+  for (const el of behindTheSheet) el.inert = true;
+  shortcutsCloseEl.focus();
 }
 
 function closeShortcuts() {
+  if (shortcutsEl.hidden) return;
+  for (const el of behindTheSheet) el.inert = false;
   shortcutsEl.hidden = true;
+  if (focusBeforeShortcuts && focusBeforeShortcuts.isConnected) focusBeforeShortcuts.focus();
+  focusBeforeShortcuts = null;
 }
 
 document.getElementById('shortcutsBtn').addEventListener('click', openShortcuts);
-document.getElementById('shortcutsClose').addEventListener('click', closeShortcuts);
+shortcutsCloseEl.addEventListener('click', closeShortcuts);
 
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape' && !shortcutsEl.hidden) closeShortcuts();

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -57,7 +57,22 @@ function render() {
   listEl.innerHTML = '';
 
   if (notes.length === 0) {
-    listEl.innerHTML = `<div class="empty">${ICONS.notes}<div>No notes yet.<br/>Click "New" or press &#8984;&#8679;N (Ctrl+Shift+N) to create one.</div></div>`;
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.innerHTML = ICONS.notes;
+
+    const message = document.createElement('div');
+    message.textContent = 'No notes yet.';
+    message.appendChild(document.createElement('br'));
+    const newNoteKeys = shortcutDisplay('newNote');
+    message.appendChild(
+      document.createTextNode(
+        newNoteKeys ? `Click "New" or press ${newNoteKeys} to create one.` : 'Click "New" to create one.'
+      )
+    );
+
+    empty.appendChild(message);
+    listEl.appendChild(empty);
     return;
   }
   if (filtered.length === 0) {
@@ -163,6 +178,11 @@ const SCOPE_SECTIONS = [
   }
 ];
 
+function shortcutDisplay(id) {
+  const match = shortcuts.find((s) => s.id === id);
+  return match ? match.display : '';
+}
+
 function shortcutRow(shortcut) {
   const row = document.createElement('div');
   row.className = 'sc-row';
@@ -215,10 +235,13 @@ function renderShortcuts(shortcuts) {
   }
 }
 
-// Loaded once at startup; the definitions cannot change while the app runs.
+// Loaded once at startup: the legend needs it, and so does the empty state's
+// "or press …" hint. Re-renders the list because that hint can only be filled
+// in once the bindings have arrived.
 const shortcutsReady = window.manager.shortcuts().then((list) => {
   shortcuts = list;
   renderShortcuts(shortcuts);
+  render();
 });
 
 async function openShortcuts() {

--- a/manager.html
+++ b/manager.html
@@ -332,9 +332,9 @@
   <div class="list" id="list"></div>
   <div id="version"></div>
 
-  <div class="sheet" id="shortcuts" hidden>
+  <div class="sheet" id="shortcuts" hidden role="dialog" aria-modal="true" aria-labelledby="shortcutsTitle">
     <div class="sheet-head">
-      <h2>Keyboard Shortcuts</h2>
+      <h2 id="shortcutsTitle">Keyboard Shortcuts</h2>
       <button class="icon-btn" id="shortcutsClose" title="Close (Esc)" aria-label="Close">
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>

--- a/manager.html
+++ b/manager.html
@@ -30,7 +30,7 @@
     color: var(--ink);
     -webkit-font-smoothing: antialiased;
   }
-  body { display: flex; flex-direction: column; user-select: none; }
+  body { display: flex; flex-direction: column; user-select: none; position: relative; }
 
   /* ─── Toolbar ─────────────────────────────────────────── */
   .toolbar {
@@ -221,6 +221,98 @@
     border-top: 1px solid var(--border);
     background: var(--surface);
   }
+  /* ─── Shortcut legend ─────────────────────────────────── */
+  .toolbar .icon-btn {
+    flex: 0 0 auto;
+    border: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .toolbar .icon-btn:hover { background: var(--surface-2); }
+
+  .sheet {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+  }
+  /* `display: flex` above outranks the user-agent's [hidden] rule, so the
+     panel needs its own — without this it is never actually hidden. */
+  .sheet[hidden] { display: none; }
+  .sheet-head {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .sheet-head h2 {
+    flex: 1;
+    font-size: 14px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+  }
+  .sheet-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 16px 22px;
+  }
+
+  .sc-group + .sc-group { margin-top: 22px; }
+  .sc-group-title {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted-2);
+    margin-bottom: 5px;
+  }
+  .sc-group-note {
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--muted);
+    margin-bottom: 10px;
+  }
+
+  .sc-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: var(--r);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: var(--sh);
+  }
+  .sc-row + .sc-row { margin-top: 6px; }
+  .sc-text { flex: 1; min-width: 0; }
+  .sc-label {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .sc-desc {
+    font-size: 11.5px;
+    line-height: 1.45;
+    color: var(--muted);
+    margin-top: 2px;
+  }
+  .sc-keys {
+    flex: 0 0 auto;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--ink-2);
+    background: var(--surface-2);
+    border: 1px solid var(--border-2);
+    border-bottom-width: 2px;
+    border-radius: 6px;
+    padding: 4px 8px;
+    white-space: nowrap;
+  }
 </style>
 </head>
 <body>
@@ -233,9 +325,23 @@
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
       New
     </button>
+    <button class="icon-btn" id="shortcutsBtn" title="Keyboard shortcuts" aria-label="Keyboard shortcuts">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.1 9a3 3 0 015.8 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+    </button>
   </div>
   <div class="list" id="list"></div>
   <div id="version"></div>
+
+  <div class="sheet" id="shortcuts" hidden>
+    <div class="sheet-head">
+      <h2>Keyboard Shortcuts</h2>
+      <button class="icon-btn" id="shortcutsClose" title="Close (Esc)" aria-label="Close">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <div class="sheet-body" id="shortcutsBody"></div>
+  </div>
+
   <script src="manager-renderer.js"></script>
 </body>
 </html>

--- a/manager.js
+++ b/manager.js
@@ -4,7 +4,7 @@
 // touches the store directly — main.js stays the single source of truth.
 const path = require('path');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
-const { registerShortcuts } = require('./shortcuts');
+const { registerShortcuts, getShortcuts } = require('./shortcuts');
 
 const MAX_TITLE_LENGTH = 80;
 
@@ -22,10 +22,16 @@ function createManagerModule({ store, actions }) {
     }
   }
 
-  function openManagerWindow() {
+  // `showShortcuts` opens the window straight onto the shortcut legend — the
+  // tray's "Keyboard Shortcuts…" item. Also called as a plain click/shortcut
+  // handler, which passes an event object with no such property, so anything
+  // that isn't an explicit request just opens the note list as before.
+  function openManagerWindow(options = {}) {
+    const showShortcuts = !!options.showShortcuts;
     if (win && !win.isDestroyed()) {
       win.show();
       win.focus();
+      if (showShortcuts) win.webContents.send('manager:showShortcuts');
       return;
     }
     win = new BrowserWindow({
@@ -50,6 +56,11 @@ function createManagerModule({ store, actions }) {
     });
     win.loadFile('manager.html');
     win.once('ready-to-show', () => win.show());
+    // did-finish-load rather than ready-to-show: the renderer has to have run
+    // its scripts before it can be listening for this.
+    if (showShortcuts) {
+      win.webContents.once('did-finish-load', () => win.webContents.send('manager:showShortcuts'));
+    }
     win.on('closed', () => {
       win = null;
     });
@@ -57,6 +68,7 @@ function createManagerModule({ store, actions }) {
 
   ipcMain.handle('manager:list', () => store.all());
   ipcMain.handle('manager:version', () => app.getVersion());
+  ipcMain.handle('manager:shortcuts', () => getShortcuts());
 
   ipcMain.on('manager:new', () => actions.createNote());
 

--- a/platform.js
+++ b/platform.js
@@ -24,6 +24,7 @@ function isCommandOrControlPressed(input) {
 // process.platform branching — it just displays the string it is handed.
 const MAC_SYMBOLS = {
   CommandOrControl: '⌘',
+  CmdOrCtrl: '⌘',
   Command: '⌘',
   Cmd: '⌘',
   Control: '⌃',
@@ -35,6 +36,7 @@ const MAC_SYMBOLS = {
 const MAC_MODIFIER_ORDER = ['⌃', '⌥', '⇧', '⌘'];
 const WINDOWS_NAMES = {
   CommandOrControl: 'Ctrl',
+  CmdOrCtrl: 'Ctrl',
   Command: 'Ctrl',
   Cmd: 'Ctrl',
   Control: 'Ctrl',

--- a/platform.js
+++ b/platform.js
@@ -17,6 +17,53 @@ function isCommandOrControlPressed(input) {
   return isMac ? !!input.meta && !input.control : !!input.control && !input.meta;
 }
 
+// Human-readable form of an Electron accelerator, for the tray menu and the
+// in-app shortcut legend. macOS renders modifiers as symbols in a fixed order
+// (⌃⌥⇧⌘) no matter how the accelerator was written; Windows spells them out
+// and joins them with "+". Doing this here keeps the renderer free of any
+// process.platform branching — it just displays the string it is handed.
+const MAC_SYMBOLS = {
+  CommandOrControl: '⌘',
+  Command: '⌘',
+  Cmd: '⌘',
+  Control: '⌃',
+  Ctrl: '⌃',
+  Alt: '⌥',
+  Option: '⌥',
+  Shift: '⇧'
+};
+const MAC_MODIFIER_ORDER = ['⌃', '⌥', '⇧', '⌘'];
+const WINDOWS_NAMES = {
+  CommandOrControl: 'Ctrl',
+  Command: 'Ctrl',
+  Cmd: 'Ctrl',
+  Control: 'Ctrl',
+  Ctrl: 'Ctrl',
+  Alt: 'Alt',
+  Option: 'Alt',
+  Shift: 'Shift'
+};
+
+// Single characters are the key itself ("n" -> "N"); named keys such as Tab
+// or Escape are left as written.
+function displayKey(part) {
+  return part.length === 1 ? part.toUpperCase() : part;
+}
+
+function formatAccelerator(accelerator) {
+  const parts = String(accelerator || '').split('+').filter(Boolean);
+  if (parts.length === 0) return '';
+  if (isMac) {
+    const symbols = parts.map((part) => MAC_SYMBOLS[part] || displayKey(part));
+    const modifiers = symbols
+      .filter((symbol) => MAC_MODIFIER_ORDER.includes(symbol))
+      .sort((a, b) => MAC_MODIFIER_ORDER.indexOf(a) - MAC_MODIFIER_ORDER.indexOf(b));
+    const keys = symbols.filter((symbol) => !MAC_MODIFIER_ORDER.includes(symbol));
+    return modifiers.join('') + keys.join('');
+  }
+  return parts.map((part) => WINDOWS_NAMES[part] || displayKey(part)).join('+');
+}
+
 // Pin/unpin a note window. Pinned = always-on-top, stays above whatever
 // app you switch to. Unpinned = a normal window that other apps can cover
 // when they're brought to the front, on both macOS and Windows.
@@ -56,6 +103,7 @@ module.exports = {
   isWindows,
   hideDockIconIfMac,
   isCommandOrControlPressed,
+  formatAccelerator,
   setPinned,
   captureExclusionCaveat
 };

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -3,25 +3,94 @@
 // such as Cmd+Shift+N remain available to browsers and IDEs.
 const platform = require('./platform');
 
-const BINDINGS = {
-  newNote: 'CommandOrControl+Shift+N',
-  toggleHideAll: 'CommandOrControl+Shift+H',
-  toggleGhostAll: 'CommandOrControl+Shift+G',
-  openManager: 'CommandOrControl+Shift+M'
-};
+// Single source of truth for every shortcut the app answers to. The input
+// matcher, the tray menu accelerators and the in-app legend are all derived
+// from this list, so a shortcut can never be advertised as one thing while
+// doing another.
+//
+// `scope` separates the app-scoped bindings — live only while a Ghost Notes
+// window has focus — from the single global binding, which stays registered
+// system-wide so there is always a way back in when every window is hidden.
+// App-scoped bindings all share the CommandOrControl+Shift modifiers that
+// shortcutNameForInput checks; only the final key differs.
+//
+// Order is the order the legend lists them in, and follows the tray menu.
+const SHORTCUTS = [
+  {
+    id: 'newNote',
+    scope: 'app',
+    accelerator: 'CommandOrControl+Shift+N',
+    label: 'New note',
+    description: 'Drops a fresh note next to the cursor.'
+  },
+  {
+    id: 'openManager',
+    scope: 'app',
+    accelerator: 'CommandOrControl+Shift+M',
+    label: 'Notes Manager',
+    description: 'Every note you have saved, open or hidden.'
+  },
+  {
+    id: 'toggleHideAll',
+    scope: 'app',
+    accelerator: 'CommandOrControl+Shift+H',
+    label: 'Hide / show all notes',
+    description: 'Hiding keeps the contents — notes reopen exactly where they were.'
+  },
+  {
+    id: 'toggleGhostAll',
+    scope: 'app',
+    accelerator: 'CommandOrControl+Shift+G',
+    label: 'Toggle click-through',
+    description: 'Clicks pass straight through your notes. Hover a note bar to interact again.'
+  },
+  {
+    id: 'newNoteAnywhere',
+    scope: 'global',
+    accelerator: 'CommandOrControl+Alt+Shift+N',
+    label: 'New note from anywhere',
+    description: 'The only shortcut that works while another app has focus, so a new note is always reachable.'
+  }
+];
 
-const FALLBACK_BINDING = 'CommandOrControl+Alt+Shift+N';
+const APP_SHORTCUTS = SHORTCUTS.filter((shortcut) => shortcut.scope === 'app');
+const GLOBAL_SHORTCUT = SHORTCUTS.find((shortcut) => shortcut.scope === 'global');
 
-const ACTION_BY_KEY = {
-  n: 'newNote',
-  h: 'toggleHideAll',
-  g: 'toggleGhostAll',
-  m: 'openManager'
-};
+const FALLBACK_BINDING = GLOBAL_SHORTCUT.accelerator;
+
+// id -> accelerator, for callers that only need the string.
+const BINDINGS = Object.fromEntries(APP_SHORTCUTS.map((s) => [s.id, s.accelerator]));
+
+// The matcher keys off the final segment of the accelerator rather than a
+// field of its own, so the key the app listens for and the key the legend
+// prints cannot drift apart.
+function keyOf(accelerator) {
+  const parts = accelerator.split('+');
+  return parts[parts.length - 1];
+}
+
+const ACTION_BY_KEY = Object.fromEntries(
+  APP_SHORTCUTS.map((s) => [keyOf(s.accelerator).toLowerCase(), s.id])
+);
 
 const ACTION_BY_CODE = Object.fromEntries(
-  Object.entries(ACTION_BY_KEY).map(([key, action]) => [`Key${key.toUpperCase()}`, action])
+  APP_SHORTCUTS.map((s) => [`Key${keyOf(s.accelerator).toUpperCase()}`, s.id])
 );
+
+// The list every UI reads from — the tray menu and the legend in the Notes
+// Manager — with a platform-formatted `display` string so no caller has to
+// know how to render an accelerator.
+//
+// Issue #5 (customizable shortcuts) resolves user overrides on top of these
+// defaults. Keeping the definitions in one list, and deriving the matcher's
+// lookup tables from it instead of hand-maintaining a parallel copy, is what
+// makes that a change in one place rather than four.
+function getShortcuts() {
+  return SHORTCUTS.map((shortcut) => ({
+    ...shortcut,
+    display: platform.formatAccelerator(shortcut.accelerator)
+  }));
+}
 
 function shortcutNameForInput(input) {
   if (!input || input.type !== 'keyDown' || input.isAutoRepeat) return null;
@@ -57,6 +126,7 @@ module.exports = {
   registerFallbackShortcut,
   unregisterFallbackShortcut,
   shortcutNameForInput,
+  getShortcuts,
   BINDINGS,
   FALLBACK_BINDING
 };

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -152,5 +152,11 @@ test('formats accelerators the way this platform writes them', () => {
     platform.formatAccelerator('CommandOrControl+Alt+Shift+N'),
     platform.isMac ? '⌥⇧⌘N' : 'Ctrl+Alt+Shift+N'
   );
+  // CmdOrCtrl is Electron's documented alias for CommandOrControl and is used
+  // elsewhere in the app, so the formatter has to understand both spellings.
+  assert.equal(
+    platform.formatAccelerator('CmdOrCtrl+Q'),
+    platform.isMac ? '⌘Q' : 'Ctrl+Q'
+  );
   assert.equal(platform.formatAccelerator(''), '');
 });

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -8,6 +8,8 @@ const {
   registerFallbackShortcut,
   unregisterFallbackShortcut,
   shortcutNameForInput,
+  getShortcuts,
+  BINDINGS,
   FALLBACK_BINDING
 } = require('../shortcuts');
 
@@ -85,4 +87,70 @@ test('registers and unregisters the global recovery shortcut', () => {
 
   unregisterFallbackShortcut(globalShortcut);
   assert.equal(unregisteredBinding, FALLBACK_BINDING);
+});
+
+// The legend, the tray menu and the matcher all read from one definition list.
+// These guard the derivation, so a shortcut can never be displayed somewhere
+// as a binding the app does not actually answer to.
+// Builds the key event a user pressing this accelerator would actually
+// produce, so the assertion below tests the accelerator as written rather
+// than restating what the matcher already assumes.
+function inputForAccelerator(accelerator) {
+  const parts = accelerator.split('+');
+  const key = parts[parts.length - 1];
+  const modifiers = parts.slice(0, -1);
+  const primary = modifiers.includes('CommandOrControl');
+  return {
+    type: 'keyDown',
+    key,
+    code: `Key${key.toUpperCase()}`,
+    shift: modifiers.includes('Shift'),
+    alt: modifiers.includes('Alt'),
+    control: primary && !platform.isMac,
+    meta: primary && platform.isMac,
+    isAutoRepeat: false
+  };
+}
+
+test('every app-scoped shortcut in the legend is one the matcher recognizes', () => {
+  const appShortcuts = getShortcuts().filter((s) => s.scope === 'app');
+  assert.ok(appShortcuts.length > 0);
+
+  for (const shortcut of appShortcuts) {
+    assert.equal(
+      shortcutNameForInput(inputForAccelerator(shortcut.accelerator)),
+      shortcut.id,
+      `${shortcut.label} is listed as ${shortcut.accelerator} but the matcher does not answer to it`
+    );
+    assert.equal(shortcut.accelerator, BINDINGS[shortcut.id]);
+  }
+});
+
+test('the legend describes every shortcut and formats it for this platform', () => {
+  for (const shortcut of getShortcuts()) {
+    assert.ok(shortcut.label, `${shortcut.id} has no label`);
+    assert.ok(shortcut.description, `${shortcut.id} has no description`);
+    assert.equal(shortcut.display, platform.formatAccelerator(shortcut.accelerator));
+    assert.ok(!shortcut.display.includes('CommandOrControl'), 'display string is not human-readable');
+  }
+});
+
+test('the legend lists the global recovery shortcut alongside the app ones', () => {
+  const global = getShortcuts().filter((s) => s.scope === 'global');
+  assert.equal(global.length, 1);
+  assert.equal(global[0].accelerator, FALLBACK_BINDING);
+});
+
+test('formats accelerators the way this platform writes them', () => {
+  assert.equal(
+    platform.formatAccelerator('CommandOrControl+Shift+N'),
+    platform.isMac ? '⇧⌘N' : 'Ctrl+Shift+N'
+  );
+  // macOS orders modifiers ctrl-opt-shift-cmd regardless of how the
+  // accelerator was written; Windows keeps the written order.
+  assert.equal(
+    platform.formatAccelerator('CommandOrControl+Alt+Shift+N'),
+    platform.isMac ? '⌥⇧⌘N' : 'Ctrl+Alt+Shift+N'
+  );
+  assert.equal(platform.formatAccelerator(''), '');
 });


### PR DESCRIPTION
## Description

Right now you have to leave Ghost Notes to find out how to use Ghost Notes. This adds a shortcut legend inside the app — tray icon → **Keyboard Shortcuts…**, or the **?** in the Notes Manager toolbar.

It's grouped into **In Ghost Notes** and **Anywhere**, which makes the distinction #18 introduced visible to users for the first time. The global `Cmd/Ctrl+Alt+Shift+N` recovery binding is listed too — previously you could only find it by reading the README.

One refactor rides along, because displaying shortcuts wasn't safe without it. The accelerators were written out in four places — `BINDINGS`, the `ACTION_BY_KEY` matcher table, the tray menu, and the manager's empty state — so any surface showing them could drift from what the app actually answers to. They now all derive from a single list, and the matcher takes its key from the accelerator itself, so the key you press and the key you're shown can't disagree.

## Related Issue

Refs #20

Scoped to the read-only legend, per the discussion on the issue — remapping and persistence stay with #5 (@uncaughtx). `getShortcuts()` is the seam between them: #5 resolves user overrides behind it, and the legend, tray menu and empty-state hint all pick those up with no further changes.

## Changes Made

- One `SHORTCUTS` definition list in `shortcuts.js` that the matcher, tray menu, empty-state hint and legend all read from
- The legend panel itself, in the Notes Manager
- `platform.formatAccelerator()`, so keys render per-OS (`⇧⌘N` vs `Ctrl+Shift+N`) and the renderer never branches on platform

Split into focused commits so the refactor and the feature can be read separately

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux (if applicable)

`npm test` — 9 passing (5 existing, 4 new). The new tests build the key event from each accelerator as written, rather than restating what the matcher already assumes, so a shortcut that's listed but unreachable fails the suite. I checked that actually works by injecting the drift.

**Steps to reproduce / verify:**
1. Tray icon → **Keyboard Shortcuts…** — opens the Notes Manager straight onto the legend.
2. Or open the Notes Manager and click **?**. Escape closes it.
3. Confirm the keys shown match your platform and match what the app really does.
4. With no notes saved, the empty state's hint should show the real New note binding.

I'm on Windows, so a macOS check would be welcome — the `⇧⌘N` symbol path is covered by tests but I haven't seen it on a real Mac.


## Screenshots / Recordings (if applicable)


https://github.com/user-attachments/assets/b37ccbfc-96ec-4130-bf49-863ce5bdfa48

<img width="314" height="506" alt="Screenshot 2026-09-02 014152" src="https://github.com/user-attachments/assets/b2f45550-8b73-4855-b52c-23da6560da09" />



## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`


