### PR TITLE
Add Export and Import Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Close a note:** ✕ in the hover bar — this **hides** the note, it does not delete it. The note stays in the Notes Manager and can be reopened any time.
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
 - **Keyboard shortcuts list:** tray icon → Keyboard Shortcuts…, or the **?** button in the Notes Manager — every active shortcut, written the way your platform writes it
+- **Backup / migrate notes:** the download/upload buttons in the Notes Manager toolbar. "Export All Notes" writes every note to a plain JSON backup file (the file itself is not encrypted — keep it somewhere safe); "Import Notes" restores a backup, either merging it with your current notes or replacing them.
 - **Quit:** tray icon → Quit
 
 The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden. You never have to come back here to look any of this up — the in-app list under **Keyboard Shortcuts…** shows the same thing.

--- a/main.js
+++ b/main.js
@@ -280,6 +280,14 @@ function importNotes(records, mode) {
   let added = 0;
   let skipped = 0;
 
+  // Imported records can carry workspaceIds from the backup that don't exist
+  // locally (import doesn't restore workspaces). Those notes would become
+  // unreachable — the manager filters by active workspace — so remap any
+  // unknown id onto the active workspace before saving.
+  const workspaceIds = new Set(store.workspaces().map((w) => w.id));
+  const fallbackWorkspaceId = store.activeWorkspaceId();
+  records = records.map((r) => (workspaceIds.has(r.workspaceId) ? r : { ...r, workspaceId: fallbackWorkspaceId }));
+
   if (mode === 'replace') {
     // Close every note window first so no window outlives its record — and
     // no window keeps stale content for an imported record that happens to
@@ -314,7 +322,7 @@ function importNotes(records, mode) {
     if (safe.x !== record.x || safe.y !== record.y) {
       store.update(record.id, { x: safe.x, y: safe.y, width: safe.width, height: safe.height, displayId: safe.displayId });
     }
-    if (record.visible) openNoteWindow(store.get(record.id));
+    if (record.visible && record.workspaceId === store.activeWorkspaceId()) openNoteWindow(store.get(record.id));
   }
 
   updateTrayMenu();

--- a/main.js
+++ b/main.js
@@ -97,7 +97,8 @@ function createManager() {
       createWorkspace: (name) => createWorkspace(name),
       renameWorkspace: (id, name) => renameWorkspace(id, name),
       removeWorkspace: (id) => removeWorkspace(id),
-      moveNoteToWorkspace: (noteId, workspaceId) => moveNoteToWorkspace(noteId, workspaceId)
+      moveNoteToWorkspace: (noteId, workspaceId) => moveNoteToWorkspace(noteId, workspaceId),
+      importNotes: (records, mode) => importNotes(records, mode)
     }
   });
 }
@@ -273,6 +274,54 @@ function createNoteNearCursor() {
 
 // Scoped to the active workspace, because "hide all" should never reach into a
 // workspace the user isn't looking at and rewrite its notes' visibility.
+// Import (backup restore / migration). The store mutation is bulk; the
+// delicate part is reconciling note windows to the new record set.
+function importNotes(records, mode) {
+  let added = 0;
+  let skipped = 0;
+
+  if (mode === 'replace') {
+    // Close every note window first so no window outlives its record — and
+    // no window keeps stale content for an imported record that happens to
+    // reuse an existing id. They are reopened fresh from the new store below.
+    for (const win of noteWindows.values()) {
+      if (!win.isDestroyed()) win.destroy();
+    }
+    noteWindows.clear();
+    store.replaceAll(records);
+    added = records.length;
+  } else {
+    // Merge: existing notes win on duplicate ids, imported duplicates are
+    // counted so the manager can report how many were skipped.
+    const existingIds = new Set(store.all().map((n) => n.id));
+    const fresh = [];
+    for (const record of records) {
+      if (existingIds.has(record.id)) skipped++;
+      else fresh.push(record);
+    }
+    store.replaceAll([...store.all(), ...fresh]);
+    added = fresh.length;
+  }
+
+  // Records without a window are the imported ones. Their saved positions
+  // may belong to monitors that don't exist on this machine, so clamp them
+  // onto a visible display before showing them (same recovery the app uses
+  // at startup after display changes). On-screen notes keep their exact
+  // exported position and timestamps.
+  for (const record of store.all()) {
+    if (noteWindows.has(record.id)) continue;
+    const safe = clampToVisibleDisplay({ x: record.x, y: record.y, width: record.width, height: record.height });
+    if (safe.x !== record.x || safe.y !== record.y) {
+      store.update(record.id, { x: safe.x, y: safe.y, width: safe.width, height: safe.height, displayId: safe.displayId });
+    }
+    if (record.visible) openNoteWindow(store.get(record.id));
+  }
+
+  updateTrayMenu();
+  manager.notifyChanged();
+  return { added, skipped };
+}
+
 function toggleHideAll() {
   const records = store.notesInWorkspace(store.activeWorkspaceId());
   const anyVisible = records.some((n) => n.visible);

--- a/manager-preload.js
+++ b/manager-preload.js
@@ -17,5 +17,7 @@ contextBridge.exposeInMainWorld('manager', {
   createWorkspace: (name) => ipcRenderer.send('manager:createWorkspace', name),
   renameWorkspace: (id, name) => ipcRenderer.send('manager:renameWorkspace', { id, name }),
   deleteWorkspace: (id) => ipcRenderer.send('manager:deleteWorkspace', id),
-  moveNote: (id, workspaceId) => ipcRenderer.send('manager:moveNote', { id, workspaceId })
+  moveNote: (id, workspaceId) => ipcRenderer.send('manager:moveNote', { id, workspaceId }),
+  exportAll: () => ipcRenderer.invoke('manager:export'),
+  importNotes: () => ipcRenderer.invoke('manager:import')
 });

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -256,6 +256,35 @@ function applySnapshot(snapshot) {
   render();
 }
 
+document.getElementById('exportNotes').addEventListener('click', async () => {
+  const res = await window.manager.exportAll();
+  if (res && res.ok) flashStatus(`Exported ${res.count} note${plural(res.count)}`);
+});
+
+document.getElementById('importNotes').addEventListener('click', async () => {
+  const res = await window.manager.importNotes();
+  if (res && res.ok) {
+    const dupes = res.skipped ? `, skipped ${res.skipped} duplicate${plural(res.skipped)}` : '';
+    flashStatus(`Imported ${res.added} note${plural(res.added)}${dupes}`);
+  }
+});
+
+function plural(n) {
+  return n === 1 ? '' : 's';
+}
+
+// Brief, non-modal feedback in the footer; errors already surface as native
+// dialogs from the main process.
+let statusTimer = null;
+function flashStatus(text) {
+  const el = document.getElementById('status');
+  el.textContent = text;
+  if (statusTimer) clearTimeout(statusTimer);
+  statusTimer = setTimeout(() => {
+    el.textContent = '';
+  }, 4000);
+}
+
 window.manager.onChanged(applySnapshot);
 window.manager.list().then(applySnapshot);
 

--- a/manager.html
+++ b/manager.html
@@ -315,6 +315,15 @@
   }
   .icon-btn:hover { background: var(--surface-2); color: var(--ink); }
   .icon-btn.danger:hover { background: #fdecec; color: #d3392e; }
+  /* Keyboard users need a visible focus indicator on the icon-only controls,
+     which have no text label to rely on. */
+  .btn-icon:focus-visible,
+  .icon-btn:focus-visible,
+  .move-wrap:focus-visible,
+  #workspaceSelect:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
   .actions-divider {
     width: 1px;
     height: 18px;

--- a/manager.html
+++ b/manager.html
@@ -187,6 +187,22 @@
     border-color: var(--accent);
     box-shadow: 0 0 0 3px rgba(91, 75, 255, 0.15);
   }
+  .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    flex: 0 0 auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.1s;
+  }
+  .btn-icon:hover { background: var(--surface-2); color: var(--ink); border-color: var(--border-2); }
+  .btn-icon:active { transform: scale(0.95); }
 
   /* ─── List ────────────────────────────────────────────── */
   .list {
@@ -354,12 +370,15 @@
      options need one of their own to stay readable. */
   .move-select option { color: var(--ink); }
 
-  #version {
+  #footer {
     flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
     padding: 8px 12px;
     font-size: 11px;
     color: var(--muted-2);
-    text-align: center;
     border-top: 1px solid var(--border);
     background: var(--surface);
   }
@@ -455,6 +474,14 @@
     padding: 4px 8px;
     white-space: nowrap;
   }
+  #status {
+    color: var(--accent-dk);
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  #version { white-space: nowrap; }
 </style>
 </head>
 <body>
@@ -495,9 +522,15 @@
     <button class="icon-btn" id="shortcutsBtn" title="Keyboard shortcuts" aria-label="Keyboard shortcuts">
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9.1 9a3 3 0 015.8 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
     </button>
+    <button class="btn-icon" id="exportNotes" title="Export All Notes" aria-label="Export all notes to a backup file">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+    </button>
+    <button class="btn-icon" id="importNotes" title="Import Notes" aria-label="Import notes from a backup file">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+    </button>
   </div>
   <div class="list" id="list"></div>
-  <div id="version"></div>
+  <div id="footer"><span id="status"></span><span id="version"></span></div>
 
   <div class="sheet" id="shortcuts" hidden role="dialog" aria-modal="true" aria-labelledby="shortcutsTitle">
     <div class="sheet-head">

--- a/manager.js
+++ b/manager.js
@@ -6,8 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const { registerShortcuts, getShortcuts } = require('./shortcuts');
-const { sanitizeWorkspaceName } = require('./store');
-const { STORE_VERSION, normalizeImport } = require('./store');
+const { sanitizeWorkspaceName, STORE_VERSION, normalizeImport } = require('./store');
 
 const MAX_TITLE_LENGTH = 80;
 

--- a/manager.js
+++ b/manager.js
@@ -234,7 +234,10 @@ function createManagerModule({ store, actions }) {
     } catch (_) {
       records = null;
     }
-    if (!records || records.length === 0) {
+    // null means the file isn't a backup at all. An empty array is a valid
+    // backup (notes: []) — e.g. exported from a fresh install — and must be
+    // importable so "Replace" can clear local notes.
+    if (!records) {
       dialog.showErrorBox(
         'Could not import notes',
         'That file is not a valid Ghost Notes backup — it contains no readable notes.'

--- a/manager.js
+++ b/manager.js
@@ -205,7 +205,7 @@ function createManagerModule({ store, actions }) {
       notes: store.all()
     };
     try {
-      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
+      await fs.promises.writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8');
     } catch (_) {
       dialog.showErrorBox(
         'Could not export notes',
@@ -229,7 +229,8 @@ function createManagerModule({ store, actions }) {
 
     let records = null;
     try {
-      records = normalizeImport(JSON.parse(fs.readFileSync(filePaths[0], 'utf8')));
+      const raw = await fs.promises.readFile(filePaths[0], 'utf8');
+      records = normalizeImport(JSON.parse(raw));
     } catch (_) {
       records = null;
     }

--- a/manager.js
+++ b/manager.js
@@ -1,11 +1,13 @@
 // Notes Manager: the only place a note record can be permanently deleted.
 // Owns its own BrowserWindow (singleton) and IPC surface; note lifecycle
-// actions (show/hide/delete/rename) are injected so this module never
-// touches the store directly — main.js stays the single source of truth.
+// actions (show/hide/delete/rename/import) are injected so this module never
+// mutates the store directly — main.js stays the single source of truth.
 const path = require('path');
+const fs = require('fs');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const { registerShortcuts, getShortcuts } = require('./shortcuts');
 const { sanitizeWorkspaceName } = require('./store');
+const { STORE_VERSION, normalizeImport } = require('./store');
 
 const MAX_TITLE_LENGTH = 80;
 
@@ -178,6 +180,80 @@ function createManagerModule({ store, actions }) {
       detail: 'This cannot be undone. The note will be removed from this device.'
     });
     if (response === 1) actions.deleteNoteRecord(id);
+  });
+
+  function managerWindow() {
+    return win && !win.isDestroyed() ? win : undefined;
+  }
+
+  // Export writes a PLAINTEXT JSON copy on purpose: notes.json itself is
+  // encrypted with safeStorage, which is keyed to this OS user on this
+  // machine — an encrypted backup would be unreadable on the machine the
+  // user is migrating to. The file is unencrypted, so users should store
+  // it somewhere safe (noted in the README).
+  ipcMain.handle('manager:export', async () => {
+    const { canceled, filePath } = await dialog.showSaveDialog(managerWindow(), {
+      title: 'Export All Notes',
+      defaultPath: `ghost-notes-backup-${new Date().toISOString().slice(0, 10)}.json`,
+      filters: [{ name: 'Ghost Notes Backup', extensions: ['json'] }]
+    });
+    if (canceled || !filePath) return { canceled: true };
+    const payload = {
+      app: 'ghost-notes',
+      version: STORE_VERSION,
+      exportedAt: new Date().toISOString(),
+      notes: store.all()
+    };
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
+    } catch (_) {
+      dialog.showErrorBox(
+        'Could not export notes',
+        'Ghost Notes could not write the backup file. Check that the chosen location is writable and try again.'
+      );
+      return { ok: false };
+    }
+    return { ok: true, count: payload.notes.length };
+  });
+
+  ipcMain.handle('manager:import', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog(managerWindow(), {
+      title: 'Import Notes',
+      filters: [
+        { name: 'Ghost Notes Backup', extensions: ['json'] },
+        { name: 'All Files', extensions: ['*'] }
+      ],
+      properties: ['openFile']
+    });
+    if (canceled || !filePaths || filePaths.length === 0) return { canceled: true };
+
+    let records = null;
+    try {
+      records = normalizeImport(JSON.parse(fs.readFileSync(filePaths[0], 'utf8')));
+    } catch (_) {
+      records = null;
+    }
+    if (!records || records.length === 0) {
+      dialog.showErrorBox(
+        'Could not import notes',
+        'That file is not a valid Ghost Notes backup — it contains no readable notes.'
+      );
+      return { ok: false };
+    }
+
+    const { response } = await dialog.showMessageBox(managerWindow(), {
+      type: 'question',
+      buttons: ['Cancel', 'Merge', 'Replace'],
+      defaultId: 1,
+      cancelId: 0,
+      title: 'Import notes',
+      message: `Import ${records.length} note${records.length === 1 ? '' : 's'} from this backup?`,
+      detail:
+        'Merge keeps your current notes and adds the imported ones (existing notes win on duplicates). ' +
+        'Replace deletes every current note and restores only the backup.'
+    });
+    if (response === 0) return { canceled: true };
+    return { ok: true, ...actions.importNotes(records, response === 1 ? 'merge' : 'replace') };
   });
 
   return { openManagerWindow, notifyChanged };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "invisible-notes",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "invisible-notes",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "electron": "^33.0.0",

--- a/store.js
+++ b/store.js
@@ -202,11 +202,23 @@ function migrate(data) {
 // Returns null when the payload is not a notes file at all.
 function normalizeImport(data) {
   if (!data || typeof data !== 'object' || !Array.isArray(data.notes)) return null;
+  // An empty array is intentionally importable (so "Replace" can clear notes),
+  // but that means any random JSON with notes: [] would otherwise pass. Exports
+  // always write the app marker and a numeric version, so require one of those
+  // when there is nothing else to look at.
+  if (data.notes.length === 0 && data.app !== 'ghost-notes' && !Number.isFinite(data.version)) return null;
   const seen = new Set();
   const notes = [];
   for (const entry of migrate(data).notes) {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    // defaultRecord() uses overrides.createdAt || Date.now(), so a valid epoch
+    // timestamp of 0 would be overwritten before the checks below run. Capture
+    // the raw values and restore them when they are actually finite.
+    const rawCreatedAt = entry.createdAt;
+    const rawUpdatedAt = entry.updatedAt;
     const record = defaultRecord(entry);
+    if (Number.isFinite(rawCreatedAt)) record.createdAt = rawCreatedAt;
+    if (Number.isFinite(rawUpdatedAt)) record.updatedAt = rawUpdatedAt;
     if (typeof record.id !== 'string' || !record.id) record.id = nextId();
     if (seen.has(record.id)) continue;
     seen.add(record.id);

--- a/store.js
+++ b/store.js
@@ -213,11 +213,13 @@ function normalizeImport(data) {
     if (typeof record.title !== 'string') record.title = '';
     if (typeof record.text !== 'string') record.text = '';
     if (typeof record.color !== 'string') record.color = 'yellow';
-    if (typeof record.fontSize !== 'number') record.fontSize = 15;
-    if (typeof record.x !== 'number') record.x = undefined;
-    if (typeof record.y !== 'number') record.y = undefined;
-    if (typeof record.createdAt !== 'number') record.createdAt = Date.now();
-    if (typeof record.updatedAt !== 'number') record.updatedAt = record.createdAt;
+    // typeof alone lets NaN/Infinity through; only finite numbers are valid
+    // for sizes, positions and timestamps.
+    if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
+    if (!Number.isFinite(record.x)) record.x = undefined;
+    if (!Number.isFinite(record.y)) record.y = undefined;
+    if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();
+    if (!Number.isFinite(record.updatedAt)) record.updatedAt = record.createdAt;
     notes.push(record);
   }
   return notes;

--- a/store.js
+++ b/store.js
@@ -214,8 +214,12 @@ function normalizeImport(data) {
     if (typeof record.text !== 'string') record.text = '';
     if (typeof record.color !== 'string') record.color = 'yellow';
     // typeof alone lets NaN/Infinity through; only finite numbers are valid
-    // for sizes, positions and timestamps.
+    // for sizes, positions and timestamps. width/height/opacity also get
+    // bounds so a bad backup can't produce an unusable window.
+    if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
+    if (!Number.isFinite(record.width) || record.width < 160) record.width = 300;
+    if (!Number.isFinite(record.height) || record.height < 120) record.height = 220;
     if (!Number.isFinite(record.x)) record.x = undefined;
     if (!Number.isFinite(record.y)) record.y = undefined;
     if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();

--- a/store.js
+++ b/store.js
@@ -481,7 +481,9 @@ class NoteStore {
   // Bulk swap of the whole notes array — used by import (merge or replace),
   // where callers have already normalized the records. One save instead of N.
   replaceAll(records) {
-    this.data = { version: STORE_VERSION, notes: records };
+    // Replace only the notes, preserving settings and workspaces so the
+    // workspace invariants (active workspace, membership) survive an import.
+    this.data = { ...this.data, notes: records };
     this.save();
   }
 }

--- a/store.js
+++ b/store.js
@@ -194,6 +194,35 @@ function migrate(data) {
   return normalizeWorkspaces({ ...data, notes });
 }
 
+// Convert a parsed backup file (any schema version this app has ever
+// written) into a clean list of current-schema records. Backups are
+// untrusted input — hand-edited, from another machine, or an older schema —
+// so every field the UI relies on is re-coerced to a sane type, unknown
+// fields are dropped by defaultRecord(), and duplicate ids are skipped.
+// Returns null when the payload is not a notes file at all.
+function normalizeImport(data) {
+  if (!data || typeof data !== 'object' || !Array.isArray(data.notes)) return null;
+  const seen = new Set();
+  const notes = [];
+  for (const entry of migrate(data).notes) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const record = defaultRecord(entry);
+    if (typeof record.id !== 'string' || !record.id) record.id = nextId();
+    if (seen.has(record.id)) continue;
+    seen.add(record.id);
+    if (typeof record.title !== 'string') record.title = '';
+    if (typeof record.text !== 'string') record.text = '';
+    if (typeof record.color !== 'string') record.color = 'yellow';
+    if (typeof record.fontSize !== 'number') record.fontSize = 15;
+    if (typeof record.x !== 'number') record.x = undefined;
+    if (typeof record.y !== 'number') record.y = undefined;
+    if (typeof record.createdAt !== 'number') record.createdAt = Date.now();
+    if (typeof record.updatedAt !== 'number') record.updatedAt = record.createdAt;
+    notes.push(record);
+  }
+  return notes;
+}
+
 class NoteStore {
   // onCorrupted(backupPath) and onWriteError(error) are optional hooks so the
   // caller (main.js) can surface a friendly, non-technical notice — this
@@ -448,11 +477,19 @@ class NoteStore {
     this.save();
     return record;
   }
+
+  // Bulk swap of the whole notes array — used by import (merge or replace),
+  // where callers have already normalized the records. One save instead of N.
+  replaceAll(records) {
+    this.data = { version: STORE_VERSION, notes: records };
+    this.save();
+  }
 }
 
 module.exports = {
   NoteStore,
   defaultRecord,
+  normalizeImport,
   STORE_VERSION,
   DEFAULT_WORKSPACE_ID,
   sanitizeWorkspaceName

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -294,7 +294,22 @@ test('normalizeImport returns null for a payload that is not a backup', () => {
 });
 
 test('normalizeImport accepts a valid empty backup', () => {
+  assert.deepEqual(normalizeImport({ app: 'ghost-notes', version: STORE_VERSION, notes: [] }), []);
   assert.deepEqual(normalizeImport({ version: STORE_VERSION, notes: [] }), []);
+});
+
+test('normalizeImport rejects empty notes without a backup marker', () => {
+  assert.equal(normalizeImport({ notes: [] }), null);
+  assert.equal(normalizeImport({ app: 'other-app', notes: [] }), null);
+});
+
+test('normalizeImport preserves a valid epoch timestamp of 0', () => {
+  const records = normalizeImport({
+    version: STORE_VERSION,
+    notes: [{ id: 'a', createdAt: 0, updatedAt: 0 }]
+  });
+  assert.equal(records[0].createdAt, 0);
+  assert.equal(records[0].updatedAt, 0);
 });
 
 test('normalizeImport coerces malformed numeric fields to sane values', () => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { NoteStore, STORE_VERSION, DEFAULT_WORKSPACE_ID } = require('../store');
+const { NoteStore, normalizeImport, STORE_VERSION, DEFAULT_WORKSPACE_ID } = require('../store');
 
 const tempDirs = [];
 const stores = [];
@@ -284,4 +284,67 @@ test('malformed entries are dropped without taking valid notes with them', () =>
   assert.equal(store.get('a').text, 'real');
   assert.equal(store.get('b').text, 'also real');
   assert.ok(store.all().every((n) => !!store.getWorkspace(n.workspaceId)));
+});
+
+test('normalizeImport returns null for a payload that is not a backup', () => {
+  assert.equal(normalizeImport(null), null);
+  assert.equal(normalizeImport({}), null);
+  assert.equal(normalizeImport({ notes: 'nope' }), null);
+  assert.equal(normalizeImport(42), null);
+});
+
+test('normalizeImport accepts a valid empty backup', () => {
+  assert.deepEqual(normalizeImport({ version: STORE_VERSION, notes: [] }), []);
+});
+
+test('normalizeImport coerces malformed numeric fields to sane values', () => {
+  const records = normalizeImport({
+    version: STORE_VERSION,
+    notes: [{
+      id: 'a',
+      width: NaN,
+      height: 5,
+      opacity: 2,
+      fontSize: 'large',
+      x: Infinity,
+      y: 'nope',
+      createdAt: 'today'
+    }]
+  });
+  assert.equal(records.length, 1);
+  const r = records[0];
+  assert.equal(r.width, 300);
+  assert.equal(r.height, 220);
+  assert.equal(r.opacity, 0.85);
+  assert.equal(r.fontSize, 15);
+  assert.equal(r.x, undefined);
+  assert.equal(r.y, undefined);
+  assert.equal(typeof r.createdAt, 'number');
+  assert.equal(r.updatedAt, r.createdAt);
+});
+
+test('normalizeImport drops duplicate and malformed entries', () => {
+  const records = normalizeImport({
+    version: STORE_VERSION,
+    notes: [
+      { id: 'a', text: 'one' },
+      { id: 'a', text: 'duplicate' },
+      null,
+      42,
+      { id: 'b', text: 'two' }
+    ]
+  });
+  assert.deepEqual(records.map((r) => r.id), ['a', 'b']);
+});
+
+test('replaceAll replaces notes but preserves settings and workspaces', () => {
+  const store = freshStore();
+  const ws = store.createWorkspace('Work');
+  store.create({ text: 'before', workspaceId: ws.id });
+
+  store.replaceAll([{ id: 'imported', text: 'after', workspaceId: ws.id }]);
+
+  assert.deepEqual(store.all().map((n) => n.id), ['imported']);
+  assert.equal(store.getWorkspace(ws.id).name, 'Work');
+  assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
 });


### PR DESCRIPTION
## Description

Adds "Export All Notes" and "Import Notes" to the Notes Manager so users can back
up their notes or migrate them to another machine, since all data is local and
not synced to the cloud.


## Related Issue

Closes #6

## Changes Made

- Added "Export All Notes" and "Import Notes" buttons to `manager.html`
- Added `exportAll`/`importNotes` IPC bindings in `manager-preload.js`
- Added `manager:export` (via `dialog.showSaveDialog`) and `manager:import`
  (via `dialog.showOpenDialog`) handlers in `manager.js`
- Added `normalizeImport` in `store.js` to coerce any backup schema to current
  records; added `replaceAll` for a single save on import
- Added merge/replace logic in `main.js` and refresh via `manager.notifyChanged()`
- Fixed `replaceAll` to preserve `settings` and `workspaces` so import and
  subsequent delete keep working


## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (if applicable)

**Steps to reproduce / verify:**
1. Open Notes Manager (Cmd/Ctrl+Shift+M)
2. Click "Export All Notes", choose a location, confirm the `.json` file is written
3. Click "Import Notes", pick that file, choose "Merge" notes appear, duplicates skipped
4. Choose "Replace" only the backup's notes remain
5. Delete a note after importing to confirm nothing else breaks

## Screenshots / Recordings (if applicable)

[Screencast_20260903_003338.webm](https://github.com/user-attachments/assets/10978728-5699-49ce-9cdf-07af0f366e98)

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [ ] Platform-specific logic (if any) is isolated inside `platform.js`
