### PR TITLE
fix(note): keep toolbar controls visible at default width

### DIFF
--- a/displayUtils.js
+++ b/displayUtils.js
@@ -2,6 +2,7 @@
 // monitor is disconnected, or the saved position lands outside any
 // currently connected display's work area.
 const { screen } = require('electron');
+const { DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./store');
 
 function rectsIntersect(a, b) {
   return a.x < b.x + b.width && a.x + a.width > b.x &&
@@ -11,8 +12,8 @@ function rectsIntersect(a, b) {
 // Returns { x, y, width, height, displayId } guaranteed to be at least
 // partially on-screen on some connected display.
 function clampToVisibleDisplay({ x, y, width, height }) {
-  const w = width || 300;
-  const h = height || 220;
+  const w = width || DEFAULT_NOTE_WIDTH;
+  const h = height || DEFAULT_NOTE_HEIGHT;
   const displays = screen.getAllDisplays();
 
   if (typeof x === 'number' && typeof y === 'number') {

--- a/displayUtils.js
+++ b/displayUtils.js
@@ -2,7 +2,7 @@
 // monitor is disconnected, or the saved position lands outside any
 // currently connected display's work area.
 const { screen } = require('electron');
-const { DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./store');
+const { DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./noteSize');
 
 function rectsIntersect(a, b) {
   return a.x < b.x + b.width && a.x + a.width > b.x &&

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ const {
   globalShortcut
 } = require('electron');
 const path = require('path');
-const { NoteStore } = require('./store');
+const { NoteStore, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./store');
 const platform = require('./platform');
 const { createNoteWindow, applyContentProtection } = require('./noteWindow');
 const { clampToVisibleDisplay, displayIdForPoint } = require('./displayUtils');
@@ -263,8 +263,8 @@ function createNoteNearCursor() {
   const wa = display.workArea;
   // Cascade a little so stacked notes don't perfectly overlap.
   const offset = (noteWindows.size % 6) * 26;
-  const x = Math.min(cursor.x, wa.x + wa.width - 320) + offset;
-  const y = Math.min(cursor.y, wa.y + wa.height - 240) + offset;
+  const x = Math.min(cursor.x, wa.x + wa.width - (DEFAULT_NOTE_WIDTH + 20)) + offset;
+  const y = Math.min(cursor.y, wa.y + wa.height - (DEFAULT_NOTE_HEIGHT + 20)) + offset;
   const record = store.create({ x, y, displayId: display.id });
   openNoteWindow(record);
   updateTrayMenu();

--- a/main.js
+++ b/main.js
@@ -11,7 +11,8 @@ const {
   globalShortcut
 } = require('electron');
 const path = require('path');
-const { NoteStore, DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./store');
+const { NoteStore } = require('./store');
+const { DEFAULT_NOTE_WIDTH, DEFAULT_NOTE_HEIGHT } = require('./noteSize');
 const platform = require('./platform');
 const { createNoteWindow, applyContentProtection } = require('./noteWindow');
 const { clampToVisibleDisplay, displayIdForPoint } = require('./displayUtils');

--- a/main.js
+++ b/main.js
@@ -264,9 +264,11 @@ function createNoteNearCursor() {
   // Cascade a little so stacked notes don't perfectly overlap.
   const offset = (noteWindows.size % 6) * 26;
   // Apply the cascade, then clamp, so stacked notes cannot sit past the
-  // work-area edge now that new notes are 360px wide.
-  const x = Math.min(cursor.x + offset, wa.x + wa.width - DEFAULT_NOTE_WIDTH);
-  const y = Math.min(cursor.y + offset, wa.y + wa.height - DEFAULT_NOTE_HEIGHT);
+  // work-area edge now that new notes are 360px wide. Math.max keeps the
+  // origin inside the work area on displays too small to fit a whole note,
+  // where the right/bottom limit would otherwise land left of / above it.
+  const x = Math.max(wa.x, Math.min(cursor.x + offset, wa.x + wa.width - DEFAULT_NOTE_WIDTH));
+  const y = Math.max(wa.y, Math.min(cursor.y + offset, wa.y + wa.height - DEFAULT_NOTE_HEIGHT));
   const record = store.create({ x, y, displayId: display.id });
   openNoteWindow(record);
   updateTrayMenu();

--- a/main.js
+++ b/main.js
@@ -264,10 +264,10 @@ function createNoteNearCursor() {
   const wa = display.workArea;
   // Cascade a little so stacked notes don't perfectly overlap.
   const offset = (noteWindows.size % 6) * 26;
-  // Apply the cascade, then clamp, so stacked notes cannot sit past the
-  // work-area edge now that new notes are 360px wide. Math.max keeps the
-  // origin inside the work area on displays too small to fit a whole note,
-  // where the right/bottom limit would otherwise land left of / above it.
+  // Clamp after applying the cascade, so a stacked note cannot be pushed past
+  // the work-area edge. The Math.max keeps the origin inside the work area on
+  // displays too small to fit a whole note, where the right/bottom limit would
+  // otherwise land left of / above the work area itself.
   const x = Math.max(wa.x, Math.min(cursor.x + offset, wa.x + wa.width - DEFAULT_NOTE_WIDTH));
   const y = Math.max(wa.y, Math.min(cursor.y + offset, wa.y + wa.height - DEFAULT_NOTE_HEIGHT));
   const record = store.create({ x, y, displayId: display.id });

--- a/main.js
+++ b/main.js
@@ -263,8 +263,10 @@ function createNoteNearCursor() {
   const wa = display.workArea;
   // Cascade a little so stacked notes don't perfectly overlap.
   const offset = (noteWindows.size % 6) * 26;
-  const x = Math.min(cursor.x, wa.x + wa.width - (DEFAULT_NOTE_WIDTH + 20)) + offset;
-  const y = Math.min(cursor.y, wa.y + wa.height - (DEFAULT_NOTE_HEIGHT + 20)) + offset;
+  // Apply the cascade, then clamp, so stacked notes cannot sit past the
+  // work-area edge now that new notes are 360px wide.
+  const x = Math.min(cursor.x + offset, wa.x + wa.width - DEFAULT_NOTE_WIDTH);
+  const y = Math.min(cursor.y + offset, wa.y + wa.height - DEFAULT_NOTE_HEIGHT);
   const record = store.create({ x, y, displayId: display.id });
   openNoteWindow(record);
   updateTrayMenu();

--- a/note.html
+++ b/note.html
@@ -36,9 +36,10 @@
   }
 
   /* Drag handle / toolbar.
-     Compact metrics so every control (including New/Close) fits inside the
-     300px default note width (issue #24). Buttons do not shrink; the spacer
-     and opacity slider give way first. */
+     Compact metrics so every control (including New/Close) fits inside
+     legacy 300px notes and the 280px window minimum (issue #24). New notes
+     default to 360px. Buttons do not shrink; the spacer and opacity slider
+     give way first. */
   .bar {
     height: 30px;
     flex: 0 0 30px;

--- a/note.html
+++ b/note.html
@@ -35,14 +35,18 @@
     box-shadow: 0 6px 22px rgba(0, 0, 0, 0.18);
   }
 
-  /* Drag handle / toolbar */
+  /* Drag handle / toolbar.
+     Compact metrics so every control (including New/Close) fits inside the
+     300px default note width (issue #24). Buttons do not shrink; the spacer
+     and opacity slider give way first. */
   .bar {
     height: 30px;
     flex: 0 0 30px;
     display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 0 8px;
+    gap: 3px;
+    padding: 0 6px;
+    min-width: 0;
     -webkit-app-region: drag;
     background: rgba(0, 0, 0, 0.06);
     opacity: 0;
@@ -69,7 +73,7 @@
   #mono.active { opacity: 1; background: rgba(0,0,0,0.12); }
   body.dark #mono.active { background: rgba(255,255,255,0.18); }
 
-  .color-control { position: relative; -webkit-app-region: no-drag; }
+  .color-control { position: relative; flex: 0 0 auto; -webkit-app-region: no-drag; }
   .color-dot {
     display: block;
     width: 14px; height: 14px; border-radius: 50%;
@@ -106,7 +110,7 @@
   }
   .swatch.active { box-shadow: 0 0 0 2px rgba(0,0,0,0.4); }
 
-  .spacer { flex: 1; }
+  .spacer { flex: 1 1 0; min-width: 0; }
 
   .btn {
     -webkit-app-region: no-drag;
@@ -116,14 +120,17 @@
     color: rgba(0,0,0,0.55);
     font-size: 15px;
     line-height: 1;
-    padding: 2px 5px;
+    padding: 2px 3px;
     border-radius: 5px;
+    flex: 0 0 auto;
   }
   .btn:hover { background: rgba(0,0,0,0.12); color: rgba(0,0,0,0.8); }
 
   input[type=range] {
     -webkit-app-region: no-drag;
-    width: 58px;
+    width: 42px;
+    min-width: 32px;
+    flex: 0 1 42px;
     accent-color: rgba(0,0,0,0.5);
     cursor: pointer;
   }

--- a/note.html
+++ b/note.html
@@ -36,10 +36,10 @@
   }
 
   /* Drag handle / toolbar.
-     Compact metrics so every control (including New/Close) fits inside
-     legacy 300px notes and the 280px window minimum (issue #24). New notes
-     default to 360px. Buttons do not shrink; the spacer and opacity slider
-     give way first. */
+     Metrics are kept tight so the full set of controls still fits at the
+     narrowest window width the app allows, and at the smaller widths older
+     notes may have been saved at. Buttons never shrink; the spacer and the
+     opacity slider absorb the loss first. */
   .bar {
     height: 30px;
     flex: 0 0 30px;

--- a/noteSize.js
+++ b/noteSize.js
@@ -7,8 +7,8 @@ const DEFAULT_NOTE_WIDTH = 360;
 const DEFAULT_NOTE_HEIGHT = 220;
 
 // Smallest a note window may be. Enforced as BrowserWindow minWidth/minHeight
-// and used to raise undersized sizes coming from disk or an import, so the
-// hover toolbar always has room for every control (issue #24).
+// and used to raise undersized sizes coming from disk or an import. The floor
+// is set by the hover toolbar: below it, the trailing controls get clipped.
 const MIN_NOTE_WIDTH = 280;
 const MIN_NOTE_HEIGHT = 120;
 

--- a/noteSize.js
+++ b/noteSize.js
@@ -1,0 +1,20 @@
+// Note geometry, kept apart from persistence and window code so the store,
+// the window builder and the placement helpers all agree on one set of
+// numbers without depending on each other.
+
+// Size a brand new note is created at.
+const DEFAULT_NOTE_WIDTH = 360;
+const DEFAULT_NOTE_HEIGHT = 220;
+
+// Smallest a note window may be. Enforced as BrowserWindow minWidth/minHeight
+// and used to raise undersized sizes coming from disk or an import, so the
+// hover toolbar always has room for every control (issue #24).
+const MIN_NOTE_WIDTH = 280;
+const MIN_NOTE_HEIGHT = 120;
+
+module.exports = {
+  DEFAULT_NOTE_WIDTH,
+  DEFAULT_NOTE_HEIGHT,
+  MIN_NOTE_WIDTH,
+  MIN_NOTE_HEIGHT
+};

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { BrowserWindow } = require('electron');
 const platform = require('./platform');
 const { clampToVisibleDisplay } = require('./displayUtils');
-const { MIN_NOTE_WIDTH, MIN_NOTE_HEIGHT } = require('./store');
+const { MIN_NOTE_WIDTH, MIN_NOTE_HEIGHT } = require('./noteSize');
 
 // Apply (or re-apply) screen-capture exclusion on a window.
 // On Windows, some Electron versions clear the SetWindowDisplayAffinity flag

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -42,7 +42,7 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
     resizable: true,
     hasShadow: false,
     skipTaskbar: true,
-    // Keep the hover toolbar fully visible (issue #24). 160px clipped New/Close.
+    // Floor the window at the size the hover toolbar needs to render in full.
     minWidth: MIN_NOTE_WIDTH,
     minHeight: MIN_NOTE_HEIGHT,
     backgroundColor: '#00000000',

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -33,7 +33,8 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
     resizable: true,
     hasShadow: false,
     skipTaskbar: true,
-    minWidth: 160,
+    // Keep the hover toolbar fully visible (issue #24). 160px clipped New/Close.
+    minWidth: 280,
     minHeight: 120,
     backgroundColor: '#00000000',
     show: false,

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -20,8 +20,19 @@ function applyContentProtection(win) {
   win.setContentProtection(true);
 }
 
+const MIN_WIDTH = 280;
+const MIN_HEIGHT = 120;
+
 function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
-  const bounds = clampToVisibleDisplay(record);
+  // Notes saved before minWidth/minHeight were raised can still have a
+  // smaller width/height on disk. Clamp to the enforced minimums before
+  // computing placement so clampToVisibleDisplay positions the note for
+  // the size it will actually render at, not the stale saved size.
+  const bounds = clampToVisibleDisplay({
+    ...record,
+    width: Math.max(record.width || 0, MIN_WIDTH),
+    height: Math.max(record.height || 0, MIN_HEIGHT)
+  });
 
   const win = new BrowserWindow({
     width: bounds.width,
@@ -34,8 +45,8 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
     hasShadow: false,
     skipTaskbar: true,
     // Keep the hover toolbar fully visible (issue #24). 160px clipped New/Close.
-    minWidth: 280,
-    minHeight: 120,
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
     backgroundColor: '#00000000',
     show: false,
     webPreferences: {

--- a/noteWindow.js
+++ b/noteWindow.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { BrowserWindow } = require('electron');
 const platform = require('./platform');
 const { clampToVisibleDisplay } = require('./displayUtils');
+const { MIN_NOTE_WIDTH, MIN_NOTE_HEIGHT } = require('./store');
 
 // Apply (or re-apply) screen-capture exclusion on a window.
 // On Windows, some Electron versions clear the SetWindowDisplayAffinity flag
@@ -20,9 +21,6 @@ function applyContentProtection(win) {
   win.setContentProtection(true);
 }
 
-const MIN_WIDTH = 280;
-const MIN_HEIGHT = 120;
-
 function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
   // Notes saved before minWidth/minHeight were raised can still have a
   // smaller width/height on disk. Clamp to the enforced minimums before
@@ -30,8 +28,8 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
   // the size it will actually render at, not the stale saved size.
   const bounds = clampToVisibleDisplay({
     ...record,
-    width: Math.max(record.width || 0, MIN_WIDTH),
-    height: Math.max(record.height || 0, MIN_HEIGHT)
+    width: Math.max(record.width || 0, MIN_NOTE_WIDTH),
+    height: Math.max(record.height || 0, MIN_NOTE_HEIGHT)
   });
 
   const win = new BrowserWindow({
@@ -45,8 +43,8 @@ function createNoteWindow(record, { onMoved, onResized, onClosed } = {}) {
     hasShadow: false,
     skipTaskbar: true,
     // Keep the hover toolbar fully visible (issue #24). 160px clipped New/Close.
-    minWidth: MIN_WIDTH,
-    minHeight: MIN_HEIGHT,
+    minWidth: MIN_NOTE_WIDTH,
+    minHeight: MIN_NOTE_HEIGHT,
     backgroundColor: '#00000000',
     show: false,
     webPreferences: {

--- a/store.js
+++ b/store.js
@@ -236,8 +236,8 @@ function normalizeImport(data) {
     // bounds so a bad backup can't produce an unusable window.
     if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
-    if (!Number.isFinite(record.width) || record.width < 160) record.width = 300;
-    if (!Number.isFinite(record.height) || record.height < 120) record.height = 220;
+    if (!Number.isFinite(record.width) || record.width < 280) record.width = DEFAULT_NOTE_WIDTH;
+    if (!Number.isFinite(record.height) || record.height < 120) record.height = DEFAULT_NOTE_HEIGHT;
     if (!Number.isFinite(record.x)) record.x = undefined;
     if (!Number.isFinite(record.y)) record.y = undefined;
     if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();

--- a/store.js
+++ b/store.js
@@ -6,17 +6,12 @@ const path = require('path');
 
 const STORE_VERSION = 6;
 
-// Default note size. The hover toolbar is compacted to fit inside 300px
-// (issue #24) so existing notes stay usable; new notes get a little extra
-// width so New/Close aren't flush against the edge.
-const DEFAULT_NOTE_WIDTH = 360;
-const DEFAULT_NOTE_HEIGHT = 220;
-
-// Smallest a note window may be. Enforced as BrowserWindow minWidth/minHeight
-// in noteWindow.js and used to clamp sizes coming from disk or an import, so
-// the two can't drift apart.
-const MIN_NOTE_WIDTH = 280;
-const MIN_NOTE_HEIGHT = 120;
+const {
+  DEFAULT_NOTE_WIDTH,
+  DEFAULT_NOTE_HEIGHT,
+  MIN_NOTE_WIDTH,
+  MIN_NOTE_HEIGHT
+} = require('./noteSize');
 
 // The workspace every migrated note lands in. The id is fixed so migrations
 // have a stable target and so the "where do orphaned notes go" fallback has
@@ -528,10 +523,6 @@ module.exports = {
   defaultRecord,
   normalizeImport,
   STORE_VERSION,
-  DEFAULT_NOTE_WIDTH,
-  DEFAULT_NOTE_HEIGHT,
-  MIN_NOTE_WIDTH,
-  MIN_NOTE_HEIGHT,
   DEFAULT_WORKSPACE_ID,
   sanitizeWorkspaceName
 };

--- a/store.js
+++ b/store.js
@@ -237,9 +237,9 @@ function normalizeImport(data) {
     // bounds so a bad backup can't produce an unusable window.
     if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
-    // A missing/garbage size falls back to the default; a real but undersized
-    // one (e.g. from a backup made when the minimum was 160) is only raised to
-    // the minimum, so imported notes keep the size the user chose.
+    // A missing or unusable size falls back to the default; a real but
+    // undersized one (a backup written when the minimum was lower) is only
+    // raised to the minimum, so imported notes keep the size the user chose.
     if (!Number.isFinite(record.width)) record.width = DEFAULT_NOTE_WIDTH;
     else if (record.width < MIN_NOTE_WIDTH) record.width = MIN_NOTE_WIDTH;
     if (!Number.isFinite(record.height)) record.height = DEFAULT_NOTE_HEIGHT;

--- a/store.js
+++ b/store.js
@@ -12,6 +12,12 @@ const STORE_VERSION = 6;
 const DEFAULT_NOTE_WIDTH = 360;
 const DEFAULT_NOTE_HEIGHT = 220;
 
+// Smallest a note window may be. Enforced as BrowserWindow minWidth/minHeight
+// in noteWindow.js and used to clamp sizes coming from disk or an import, so
+// the two can't drift apart.
+const MIN_NOTE_WIDTH = 280;
+const MIN_NOTE_HEIGHT = 120;
+
 // The workspace every migrated note lands in. The id is fixed so migrations
 // have a stable target and so the "where do orphaned notes go" fallback has
 // something to prefer.
@@ -236,8 +242,13 @@ function normalizeImport(data) {
     // bounds so a bad backup can't produce an unusable window.
     if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
-    if (!Number.isFinite(record.width) || record.width < 280) record.width = DEFAULT_NOTE_WIDTH;
-    if (!Number.isFinite(record.height) || record.height < 120) record.height = DEFAULT_NOTE_HEIGHT;
+    // A missing/garbage size falls back to the default; a real but undersized
+    // one (e.g. from a backup made when the minimum was 160) is only raised to
+    // the minimum, so imported notes keep the size the user chose.
+    if (!Number.isFinite(record.width)) record.width = DEFAULT_NOTE_WIDTH;
+    else if (record.width < MIN_NOTE_WIDTH) record.width = MIN_NOTE_WIDTH;
+    if (!Number.isFinite(record.height)) record.height = DEFAULT_NOTE_HEIGHT;
+    else if (record.height < MIN_NOTE_HEIGHT) record.height = MIN_NOTE_HEIGHT;
     if (!Number.isFinite(record.x)) record.x = undefined;
     if (!Number.isFinite(record.y)) record.y = undefined;
     if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();
@@ -519,6 +530,8 @@ module.exports = {
   STORE_VERSION,
   DEFAULT_NOTE_WIDTH,
   DEFAULT_NOTE_HEIGHT,
+  MIN_NOTE_WIDTH,
+  MIN_NOTE_HEIGHT,
   DEFAULT_WORKSPACE_ID,
   sanitizeWorkspaceName
 };

--- a/store.js
+++ b/store.js
@@ -6,6 +6,12 @@ const path = require('path');
 
 const STORE_VERSION = 6;
 
+// Default note size. The hover toolbar is compacted to fit inside 300px
+// (issue #24) so existing notes stay usable; new notes get a little extra
+// width so New/Close aren't flush against the edge.
+const DEFAULT_NOTE_WIDTH = 360;
+const DEFAULT_NOTE_HEIGHT = 220;
+
 // The workspace every migrated note lands in. The id is fixed so migrations
 // have a stable target and so the "where do orphaned notes go" fallback has
 // something to prefer.
@@ -56,8 +62,8 @@ function defaultRecord(overrides = {}) {
     color: overrides.color || 'yellow',
     x: overrides.x,
     y: overrides.y,
-    width: overrides.width || 300,
-    height: overrides.height || 220,
+    width: overrides.width || DEFAULT_NOTE_WIDTH,
+    height: overrides.height || DEFAULT_NOTE_HEIGHT,
     displayId: overrides.displayId ?? null,
     opacity: typeof overrides.opacity === 'number' ? overrides.opacity : 0.85,
     fontSize: overrides.fontSize || 15,
@@ -511,6 +517,8 @@ module.exports = {
   defaultRecord,
   normalizeImport,
   STORE_VERSION,
+  DEFAULT_NOTE_WIDTH,
+  DEFAULT_NOTE_HEIGHT,
   DEFAULT_WORKSPACE_ID,
   sanitizeWorkspaceName
 };

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -5,6 +5,11 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { NoteStore, normalizeImport, STORE_VERSION, DEFAULT_WORKSPACE_ID } = require('../store');
+const {
+  DEFAULT_NOTE_WIDTH,
+  MIN_NOTE_WIDTH,
+  MIN_NOTE_HEIGHT
+} = require('../noteSize');
 
 const tempDirs = [];
 const stores = [];
@@ -328,23 +333,6 @@ test('normalizeImport coerces malformed numeric fields to sane values', () => {
   });
   assert.equal(records.length, 1);
   const r = records[0];
-test('normalizeImport coerces malformed numeric fields to sane values', () => {
-  const { DEFAULT_NOTE_WIDTH, MIN_NOTE_HEIGHT } = require('../noteSize');
-  const records = normalizeImport({
-    version: STORE_VERSION,
-    notes: [{
-      id: 'a',
-      width: NaN,
-      height: 5,
-      opacity: 2,
-      fontSize: 'large',
-      x: Infinity,
-      y: 'nope',
-      createdAt: 'today'
-    }]
-  });
-  assert.equal(records.length, 1);
-  const r = records[0];
   // NaN is unusable, so width falls back to the default; height 5 is a real
   // number, so it is only raised to the minimum.
   assert.equal(r.width, DEFAULT_NOTE_WIDTH);
@@ -360,10 +348,10 @@ test('normalizeImport coerces malformed numeric fields to sane values', () => {
 test('normalizeImport raises an undersized note to the minimum, not the default', () => {
   const records = normalizeImport({
     version: STORE_VERSION,
-    notes: [{ id: 'a', width: 200, height: 150 }]
+    notes: [{ id: 'a', width: MIN_NOTE_WIDTH - 80, height: MIN_NOTE_HEIGHT + 30 }]
   });
-  assert.equal(records[0].width, 280);
-  assert.equal(records[0].height, 150);
+  assert.equal(records[0].width, MIN_NOTE_WIDTH);
+  assert.equal(records[0].height, MIN_NOTE_HEIGHT + 30);
 });
 
 test('normalizeImport drops duplicate and malformed entries', () => {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -328,10 +328,27 @@ test('normalizeImport coerces malformed numeric fields to sane values', () => {
   });
   assert.equal(records.length, 1);
   const r = records[0];
+test('normalizeImport coerces malformed numeric fields to sane values', () => {
+  const { DEFAULT_NOTE_WIDTH, MIN_NOTE_HEIGHT } = require('../noteSize');
+  const records = normalizeImport({
+    version: STORE_VERSION,
+    notes: [{
+      id: 'a',
+      width: NaN,
+      height: 5,
+      opacity: 2,
+      fontSize: 'large',
+      x: Infinity,
+      y: 'nope',
+      createdAt: 'today'
+    }]
+  });
+  assert.equal(records.length, 1);
+  const r = records[0];
   // NaN is unusable, so width falls back to the default; height 5 is a real
   // number, so it is only raised to the minimum.
-  assert.equal(r.width, 360);
-  assert.equal(r.height, 120);
+  assert.equal(r.width, DEFAULT_NOTE_WIDTH);
+  assert.equal(r.height, MIN_NOTE_HEIGHT);
   assert.equal(r.opacity, 0.85);
   assert.equal(r.fontSize, 15);
   assert.equal(r.x, undefined);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -328,7 +328,7 @@ test('normalizeImport coerces malformed numeric fields to sane values', () => {
   });
   assert.equal(records.length, 1);
   const r = records[0];
-  assert.equal(r.width, 300);
+  assert.equal(r.width, 360);
   assert.equal(r.height, 220);
   assert.equal(r.opacity, 0.85);
   assert.equal(r.fontSize, 15);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -328,14 +328,25 @@ test('normalizeImport coerces malformed numeric fields to sane values', () => {
   });
   assert.equal(records.length, 1);
   const r = records[0];
+  // NaN is unusable, so width falls back to the default; height 5 is a real
+  // number, so it is only raised to the minimum.
   assert.equal(r.width, 360);
-  assert.equal(r.height, 220);
+  assert.equal(r.height, 120);
   assert.equal(r.opacity, 0.85);
   assert.equal(r.fontSize, 15);
   assert.equal(r.x, undefined);
   assert.equal(r.y, undefined);
   assert.equal(typeof r.createdAt, 'number');
   assert.equal(r.updatedAt, r.createdAt);
+});
+
+test('normalizeImport raises an undersized note to the minimum, not the default', () => {
+  const records = normalizeImport({
+    version: STORE_VERSION,
+    notes: [{ id: 'a', width: 200, height: 150 }]
+  });
+  assert.equal(records[0].width, 280);
+  assert.equal(records[0].height, 150);
 });
 
 test('normalizeImport drops duplicate and malformed entries', () => {


### PR DESCRIPTION
## Description

The hover toolbar was wider than a new note's default 300px, so New (＋) and Close (✕) were clipped. Compact the bar so every control fits at 300px, give new notes a little extra width, and raise the window minimum so the bar cannot be resized into the same clip.

## Related Issue

Closes #24

## Changes Made

- Tighten toolbar gap, padding, and the opacity slider so all controls fit inside 300px (existing notes included)
- Default new notes to 360×220 so New/Close are not flush to the edge
- Raise `minWidth` from 160 to 280 so shrinking a note cannot hide the buttons again

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (if applicable)

**Steps to reproduce / verify:**
1. Create a new note — hover the toolbar; New and Close should both be fully visible.
2. Resize an existing 300×220 note if you have one — same check.
3. Drag the note as narrow as it will go — New and Close should still be clickable.

Measured at 300px: bar scroll width equals client width, Close's right edge is inside the note (no clip). Windows untested (no Windows machine).

## Screenshots / Recordings (if applicable)

Toolbar forced visible at 300×220 in a local preview; New (＋) and Close (✕) are fully on-screen. Ghost Notes itself is excluded from screen capture, so an in-app recording would not show the note.

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`

Made with [Cursor](https://cursor.com)