### PR TITLE
feature(theme): added theme support with light/dark/system options

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const {
   Tray,
   Menu,
   nativeImage,
+  nativeTheme,
   dialog,
   powerMonitor,
   safeStorage,
@@ -82,9 +83,40 @@ let tray = null;
 // createManagerModule registers IPC handlers that only act once a renderer
 // sends a message, so it can be created lazily after app is ready alongside
 // `store` (which createManagerModule closes over). See createStore() above.
+// ---------- Appearance (Manager-only theme) ----------
+// Single owner for the OS theme source. Renderers never touch nativeTheme
+// directly; they receive the resolved `effectiveDark` via manager snapshot.
+function applyThemeToOS() {
+  if (!store) return;
+  const mode = store.getTheme();
+  nativeTheme.themeSource = mode === 'system' ? 'system' : mode;
+}
+
+function resolveEffectiveDark() {
+  return nativeTheme.shouldUseDarkColors;
+}
+
+function setThemeMode(mode) {
+  if (!store || !manager) return null;
+  const clean = store.setTheme(mode);
+  applyThemeToOS();
+  manager.notifyChanged();
+  return clean;
+}
+
+function setAccentId(id) {
+  if (!store || !manager) return null;
+  const clean = store.setAccent(id);
+  manager.notifyChanged();
+  return clean;
+}
+
 function createManager() {
   return createManagerModule({
     store,
+    theme: {
+      effectiveDark: () => resolveEffectiveDark(),
+    },
     actions: {
       showNote: (id) => showNote(id),
       hideNote: (id) => hideNote(id),
@@ -98,7 +130,9 @@ function createManager() {
       renameWorkspace: (id, name) => renameWorkspace(id, name),
       removeWorkspace: (id) => removeWorkspace(id),
       moveNoteToWorkspace: (noteId, workspaceId) => moveNoteToWorkspace(noteId, workspaceId),
-      importNotes: (records, mode) => importNotes(records, mode)
+      importNotes: (records, mode) => importNotes(records, mode),
+      setTheme: (mode) => setThemeMode(mode),
+      setAccent: (id) => setAccentId(id)
     }
   });
 }
@@ -537,6 +571,10 @@ if (!gotLock) {
     // up the manager that depends on it.
     store = createStore();
     manager = createManager();
+    applyThemeToOS();
+    nativeTheme.on('updated', () => {
+      if (manager) manager.notifyChanged();
+    });
 
     setupTray();
     registerFallbackShortcut(globalShortcut, () => createNoteNearCursor());

--- a/manager-preload.js
+++ b/manager-preload.js
@@ -19,5 +19,8 @@ contextBridge.exposeInMainWorld('manager', {
   deleteWorkspace: (id) => ipcRenderer.send('manager:deleteWorkspace', id),
   moveNote: (id, workspaceId) => ipcRenderer.send('manager:moveNote', { id, workspaceId }),
   exportAll: () => ipcRenderer.invoke('manager:export'),
-  importNotes: () => ipcRenderer.invoke('manager:import')
+  importNotes: () => ipcRenderer.invoke('manager:import'),
+  // Appearance (Manager-only theme + accent)
+  setTheme: (mode) => ipcRenderer.send('manager:setTheme', mode),
+  setAccent: (id) => ipcRenderer.send('manager:setAccent', id)
 });

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -303,6 +303,7 @@ function buildAccentDots() {
     btn.dataset.accent = id;
     btn.title = def.label;
     btn.setAttribute('aria-label', def.label + ' accent');
+    btn.setAttribute('aria-pressed', 'false');
     btn.style.background = def.base;
     btn.addEventListener('click', () => window.manager.setAccent(id));
     wrap.appendChild(btn);

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -23,14 +23,16 @@ const wsNameInputEl = document.getElementById('wsNameInput');
 const wsDeleteEl = document.getElementById('wsDelete');
 
 // Curated accent palette (Manager-only). Base + pre-tested hover/light
-// variants so no runtime color math is needed. Ids must match ACCENT_IDS
-// in store.js; unknown ids fall back to violet in applyAppearance().
+// variants so no runtime color math is needed. `ltDark` is the dark-mode
+// counterpart of `lt` — inline styles beat the [data-theme="dark"] block,
+// so a single CSS fallback can't serve all five accents. Ids must match
+// ACCENT_IDS in store.js; unknown ids fall back to violet.
 const ACCENTS = {
-  violet: { base: '#5b4bff', dk: '#4a3ae8', lt: '#f0edff', label: 'Violet' },
-  blue: { base: '#2563eb', dk: '#1d4ed8', lt: '#e0eaff', label: 'Blue' },
-  green: { base: '#15803d', dk: '#166534', lt: '#dcf5e3', label: 'Green' },
-  orange: { base: '#c2410c', dk: '#9a3412', lt: '#ffe9d6', label: 'Orange' },
-  pink: { base: '#be185d', dk: '#9d174d', lt: '#fce0ec', label: 'Pink' }
+  violet: { base: '#5b4bff', dk: '#4a3ae8', lt: '#f0edff', ltDark: '#2b2666', label: 'Violet' },
+  blue: { base: '#2563eb', dk: '#1d4ed8', lt: '#e0eaff', ltDark: '#233063', label: 'Blue' },
+  green: { base: '#15803d', dk: '#166534', lt: '#dcf5e3', ltDark: '#1e3a2a', label: 'Green' },
+  orange: { base: '#c2410c', dk: '#9a3412', lt: '#ffe9d6', ltDark: '#4a2a1a', label: 'Orange' },
+  pink: { base: '#be185d', dk: '#9d174d', lt: '#fce0ec', ltDark: '#47223c', label: 'Pink' }
 };
 
 let notes = [];
@@ -282,7 +284,7 @@ function applyAppearance() {
   const accent = ACCENTS[appearance.accent] || ACCENTS.violet;
   root.style.setProperty('--accent', accent.base);
   root.style.setProperty('--accent-dk', accent.dk);
-  root.style.setProperty('--accent-lt', accent.lt);
+  root.style.setProperty('--accent-lt', appearance.effectiveDark ? accent.ltDark : accent.lt);
   document.querySelectorAll('[data-theme-opt]').forEach((btn) => {
     btn.setAttribute('aria-pressed', String(btn.dataset.themeOpt === appearance.theme));
   });

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -22,9 +22,21 @@ const wsFormEl = document.getElementById('wsForm');
 const wsNameInputEl = document.getElementById('wsNameInput');
 const wsDeleteEl = document.getElementById('wsDelete');
 
+// Curated accent palette (Manager-only). Base + pre-tested hover/light
+// variants so no runtime color math is needed. Ids must match ACCENT_IDS
+// in store.js; unknown ids fall back to violet in applyAppearance().
+const ACCENTS = {
+  violet: { base: '#5b4bff', dk: '#4a3ae8', lt: '#f0edff', label: 'Violet' },
+  blue: { base: '#2563eb', dk: '#1d4ed8', lt: '#e0eaff', label: 'Blue' },
+  green: { base: '#15803d', dk: '#166534', lt: '#dcf5e3', label: 'Green' },
+  orange: { base: '#c2410c', dk: '#9a3412', lt: '#ffe9d6', label: 'Orange' },
+  pink: { base: '#be185d', dk: '#9d174d', lt: '#fce0ec', label: 'Pink' }
+};
+
 let notes = [];
 let workspaces = [];
 let activeWorkspace = null;
+let appearance = { theme: 'system', accent: 'violet', effectiveDark: false };
 let query = '';
 let shortcuts = [];
 // null when the inline name row is closed, otherwise 'create' | 'rename'.
@@ -247,14 +259,58 @@ searchEl.addEventListener('input', () => {
 document.getElementById('newNote').addEventListener('click', () => window.manager.newNote());
 
 // Notes and workspaces always arrive together so the list can never render
-// against a stale workspace set.
+// against a stale workspace set. Theme/accent ride the same snapshot so the
+// list never paints with a stale theme.
 function applySnapshot(snapshot) {
   notes = snapshot.notes || [];
   workspaces = snapshot.workspaces || [];
   activeWorkspace = snapshot.activeWorkspace || null;
+  appearance = {
+    theme: ['light', 'dark', 'system'].includes(snapshot.theme) ? snapshot.theme : 'system',
+    accent: ACCENTS[snapshot.accent] ? snapshot.accent : 'violet',
+    effectiveDark: !!snapshot.effectiveDark
+  };
+  applyAppearance();
   renderWorkspaces();
   render();
 }
+
+// ─── Appearance (Manager-only theme + accent) ──────────────
+function applyAppearance() {
+  const root = document.documentElement;
+  root.dataset.theme = appearance.effectiveDark ? 'dark' : 'light';
+  const accent = ACCENTS[appearance.accent] || ACCENTS.violet;
+  root.style.setProperty('--accent', accent.base);
+  root.style.setProperty('--accent-dk', accent.dk);
+  root.style.setProperty('--accent-lt', accent.lt);
+  document.querySelectorAll('[data-theme-opt]').forEach((btn) => {
+    btn.setAttribute('aria-pressed', String(btn.dataset.themeOpt === appearance.theme));
+  });
+  document.querySelectorAll('#accents .accent-dot').forEach((dot) => {
+    dot.setAttribute('aria-pressed', String(dot.dataset.accent === appearance.accent));
+  });
+}
+
+function buildAccentDots() {
+  const wrap = document.getElementById('accents');
+  wrap.innerHTML = '';
+  for (const [id, def] of Object.entries(ACCENTS)) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'accent-dot';
+    btn.dataset.accent = id;
+    btn.title = def.label;
+    btn.setAttribute('aria-label', def.label + ' accent');
+    btn.style.background = def.base;
+    btn.addEventListener('click', () => window.manager.setAccent(id));
+    wrap.appendChild(btn);
+  }
+}
+
+document.querySelectorAll('[data-theme-opt]').forEach((btn) => {
+  btn.addEventListener('click', () => window.manager.setTheme(btn.dataset.themeOpt));
+});
+buildAccentDots();
 
 document.getElementById('exportNotes').addEventListener('click', async () => {
   const res = await window.manager.exportAll();

--- a/manager.html
+++ b/manager.html
@@ -604,12 +604,12 @@
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
     </button>
   </div>
-  <div class="appearance" id="appearance" aria-label="Appearance">
+  <div class="appearance" id="appearance" role="region" aria-label="Appearance">
     <span>Theme</span>
     <div class="seg" role="group" aria-label="Theme mode">
-      <button type="button" data-theme-opt="light">Light</button>
-      <button type="button" data-theme-opt="dark">Dark</button>
-      <button type="button" data-theme-opt="system">System</button>
+      <button type="button" data-theme-opt="light" aria-pressed="false">Light</button>
+      <button type="button" data-theme-opt="dark" aria-pressed="false">Dark</button>
+      <button type="button" data-theme-opt="system" aria-pressed="false">System</button>
     </div>
     <div class="accents" id="accents" role="group" aria-label="Accent color"></div>
   </div>

--- a/manager.html
+++ b/manager.html
@@ -22,6 +22,25 @@
     --sh:          0 1px 2px rgba(0,0,0,0.04), 0 1px 1px rgba(0,0,0,0.03);
     --sh-hover:    0 6px 18px rgba(20,20,30,0.08), 0 1px 3px rgba(20,20,30,0.05);
   }
+  /* Dark theme: applied via documentElement.dataset.theme === 'dark'.
+     Light is the default :root above. System mode resolves to one of the
+     two in the main process (nativeTheme) and arrives as effectiveDark. */
+  [data-theme="dark"] {
+    --accent-lt:   #2b2666;
+    --ink:         #f2f2f5;
+    --ink-2:       #e4e4ea;
+    --muted:       #a1a1b3;
+    --muted-2:     #6e6e82;
+    --border:      #2e2e3a;
+    --border-2:    #3f3f52;
+    --bg:          #141419;
+    --surface:     #1d1d26;
+    --surface-2:   #262633;
+    --sh:          0 1px 2px rgba(0,0,0,0.4);
+    --sh-hover:    0 6px 18px rgba(0,0,0,0.5);
+  }
+  [data-theme="dark"] .toolbar { background: rgba(29,29,38,0.92); }
+  [data-theme="dark"] .icon-btn.danger:hover { background: #4a2226; color: #ff8f88; }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   .sr-only {
     position: absolute;
@@ -491,6 +510,53 @@
     text-overflow: ellipsis;
   }
   #version { white-space: nowrap; }
+
+  /* ─── Appearance bar ─────────────────────────────────── */
+  .appearance {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .appearance .seg {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .appearance .seg button {
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    padding: 6px 10px;
+    cursor: pointer;
+  }
+  .appearance .seg button[aria-pressed="true"] {
+    background: var(--accent-lt);
+    color: var(--accent-dk);
+  }
+  [data-theme="dark"] .appearance .seg button[aria-pressed="true"] { color: #cfc8ff; }
+  .appearance .accents { display: inline-flex; gap: 6px; margin-left: auto; }
+  .appearance .accent-dot {
+    width: 18px; height: 18px; border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+  }
+  .appearance .accent-dot[aria-pressed="true"] { border-color: var(--ink); }
+  .appearance .accent-dot:focus-visible,
+  .appearance .seg button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
 </style>
 </head>
 <body>
@@ -537,6 +603,15 @@
     <button class="btn-icon" id="importNotes" title="Import Notes" aria-label="Import notes from a backup file">
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
     </button>
+  </div>
+  <div class="appearance" id="appearance" aria-label="Appearance">
+    <span>Theme</span>
+    <div class="seg" role="group" aria-label="Theme mode">
+      <button type="button" data-theme-opt="light">Light</button>
+      <button type="button" data-theme-opt="dark">Dark</button>
+      <button type="button" data-theme-opt="system">System</button>
+    </div>
+    <div class="accents" id="accents" role="group" aria-label="Accent color"></div>
   </div>
   <div class="list" id="list"></div>
   <div id="footer"><span id="status"></span><span id="version"></span></div>

--- a/manager.js
+++ b/manager.js
@@ -15,17 +15,21 @@ function sanitizeTitle(input) {
   return input.replace(/[\r\n]+/g, ' ').trim().slice(0, MAX_TITLE_LENGTH);
 }
 
-function createManagerModule({ store, actions }) {
+function createManagerModule({ store, actions, theme }) {
   let win = null;
 
   // One payload for both the initial load and every update, so the renderer
   // always sees notes and workspaces from the same consistent snapshot. A
   // note can never render against a workspace list that doesn't contain it.
+  // Theme/accent ride along so Manager never paints notes with a stale theme.
   function snapshot() {
     return {
       notes: store.all(),
       workspaces: store.workspaces(),
-      activeWorkspace: store.activeWorkspaceId()
+      activeWorkspace: store.activeWorkspaceId(),
+      theme: store.getTheme(),
+      accent: store.getAccent(),
+      effectiveDark: theme ? theme.effectiveDark() : false
     };
   }
 
@@ -105,6 +109,17 @@ function createManagerModule({ store, actions }) {
   ipcMain.on('manager:moveNote', (e, payload) => {
     if (!payload || typeof payload.id !== 'string' || typeof payload.workspaceId !== 'string') return;
     actions.moveNoteToWorkspace(payload.id, payload.workspaceId);
+  });
+
+  // ---------- Appearance (Manager-only theme + accent) ----------
+  ipcMain.on('manager:setTheme', (e, mode) => {
+    if (typeof mode !== 'string') return;
+    if (actions.setTheme) actions.setTheme(mode);
+  });
+
+  ipcMain.on('manager:setAccent', (e, id) => {
+    if (typeof id !== 'string') return;
+    if (actions.setAccent) actions.setAccent(id);
   });
 
   // Deleting a workspace never deletes notes, it reassigns them. The

--- a/store.js
+++ b/store.js
@@ -1,8 +1,8 @@
 // Persistence layer: versioned, atomic-write JSON store for note records.
 // A "record" is the durable note (id, content, position, visible flag) —
 // independent of whether a BrowserWindow currently exists for it.
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
 const STORE_VERSION = 6;
 
@@ -15,16 +15,16 @@ const STORE_VERSION = 6;
 // "Personal" should not be stuck with an unused "Default" forever. The
 // invariant that actually holds is that at least one workspace always exists,
 // so pickFallbackWorkspace() always has a destination.
-const DEFAULT_WORKSPACE_ID = "ws-default";
-const DEFAULT_WORKSPACE_NAME = "Default";
+const DEFAULT_WORKSPACE_ID = 'ws-default';
+const DEFAULT_WORKSPACE_NAME = 'Default';
 const MAX_WORKSPACE_NAME_LENGTH = 40;
 
 // Appearance preferences (Manager-only theming). Note bodies keep their
 // per-note color; theme/accent only restyle Manager chrome.
-const THEME_MODES = ["light", "dark", "system"];
-const DEFAULT_THEME = "system";
-const ACCENT_IDS = ["violet", "blue", "green", "orange", "pink"];
-const DEFAULT_ACCENT = "violet";
+const THEME_MODES = ['light', 'dark', 'system'];
+const DEFAULT_THEME = 'system';
+const ACCENT_IDS = ['violet', 'blue', 'green', 'orange', 'pink'];
+const DEFAULT_ACCENT = 'violet';
 
 function sanitizeTheme(input) {
   return THEME_MODES.includes(input) ? input : DEFAULT_THEME;
@@ -35,31 +35,18 @@ function sanitizeAccent(input) {
 }
 
 function nextId() {
-  return (
-    "note-" +
-    Date.now().toString(36) +
-    "-" +
-    Math.random().toString(36).slice(2, 6)
-  );
+  return 'note-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
 }
 
 function nextWorkspaceId() {
-  return (
-    "ws-" +
-    Date.now().toString(36) +
-    "-" +
-    Math.random().toString(36).slice(2, 6)
-  );
+  return 'ws-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
 }
 
 // Workspace names are shown in a tray menu, where a newline or an
 // over-long string would break the layout, so normalize at the boundary.
 function sanitizeWorkspaceName(input) {
-  if (typeof input !== "string") return "";
-  return input
-    .replace(/[\r\n]+/g, " ")
-    .trim()
-    .slice(0, MAX_WORKSPACE_NAME_LENGTH);
+  if (typeof input !== 'string') return '';
+  return input.replace(/[\r\n]+/g, ' ').trim().slice(0, MAX_WORKSPACE_NAME_LENGTH);
 }
 
 function defaultWorkspace(overrides = {}) {
@@ -67,11 +54,11 @@ function defaultWorkspace(overrides = {}) {
   // replaced rather than stored. Notes still pointing at the old value are
   // reattached by normalizeWorkspaces, which reassigns any workspaceId that
   // does not match a workspace that exists.
-  const id = typeof overrides.id === "string" ? overrides.id.trim() : "";
+  const id = typeof overrides.id === 'string' ? overrides.id.trim() : '';
   return {
     id: id || nextWorkspaceId(),
-    name: sanitizeWorkspaceName(overrides.name) || "Untitled workspace",
-    createdAt: overrides.createdAt || Date.now(),
+    name: sanitizeWorkspaceName(overrides.name) || 'Untitled workspace',
+    createdAt: overrides.createdAt || Date.now()
   };
 }
 
@@ -79,15 +66,15 @@ function defaultRecord(overrides = {}) {
   const now = overrides.createdAt || Date.now();
   return {
     id: overrides.id || nextId(),
-    title: overrides.title || "",
-    text: overrides.text || "",
-    color: overrides.color || "yellow",
+    title: overrides.title || '',
+    text: overrides.text || '',
+    color: overrides.color || 'yellow',
     x: overrides.x,
     y: overrides.y,
     width: overrides.width || 300,
     height: overrides.height || 220,
     displayId: overrides.displayId ?? null,
-    opacity: typeof overrides.opacity === "number" ? overrides.opacity : 0.85,
+    opacity: typeof overrides.opacity === 'number' ? overrides.opacity : 0.85,
     fontSize: overrides.fontSize || 15,
     // Per-note monospace toggle for code walkthroughs (issue #7).
     monospace: !!overrides.monospace,
@@ -100,7 +87,7 @@ function defaultRecord(overrides = {}) {
     // Unpinned = a normal window that can be covered by whatever's focused.
     pinned: overrides.pinned !== undefined ? !!overrides.pinned : true,
     createdAt: now,
-    updatedAt: overrides.updatedAt || now,
+    updatedAt: overrides.updatedAt || now
   };
 }
 
@@ -110,29 +97,24 @@ function defaultRecord(overrides = {}) {
 // than assuming it is "Default", which is wrong once that workspace has been
 // renamed or deleted. Returns null only for an empty list.
 function pickFallbackWorkspace(workspaces, excludeId) {
-  const remaining =
-    excludeId === undefined
-      ? workspaces
-      : workspaces.filter((w) => w.id !== excludeId);
-  return (
-    remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0] || null
-  );
+  const remaining = excludeId === undefined ? workspaces : workspaces.filter((w) => w.id !== excludeId);
+  return remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0] || null;
 }
 
 function emptyStore() {
   const workspace = defaultWorkspace({
     id: DEFAULT_WORKSPACE_ID,
-    name: DEFAULT_WORKSPACE_NAME,
+    name: DEFAULT_WORKSPACE_NAME
   });
   return {
     version: STORE_VERSION,
     settings: {
       activeWorkspace: workspace.id,
       theme: DEFAULT_THEME,
-      accent: DEFAULT_ACCENT,
+      accent: DEFAULT_ACCENT
     },
     workspaces: [workspace],
-    notes: [],
+    notes: []
   };
 }
 
@@ -155,7 +137,7 @@ function normalizeWorkspaces(data) {
   const seenIds = new Set();
   let workspaces = [];
   for (const entry of Array.isArray(data.workspaces) ? data.workspaces : []) {
-    if (!entry || typeof entry !== "object") continue;
+    if (!entry || typeof entry !== 'object') continue;
     const workspace = defaultWorkspace(entry);
     if (seenIds.has(workspace.id)) continue;
     seenIds.add(workspace.id);
@@ -163,12 +145,7 @@ function normalizeWorkspaces(data) {
   }
 
   if (workspaces.length === 0) {
-    workspaces = [
-      defaultWorkspace({
-        id: DEFAULT_WORKSPACE_ID,
-        name: DEFAULT_WORKSPACE_NAME,
-      }),
-    ];
+    workspaces = [defaultWorkspace({ id: DEFAULT_WORKSPACE_ID, name: DEFAULT_WORKSPACE_NAME })];
   }
 
   const ids = new Set(workspaces.map((w) => w.id));
@@ -176,7 +153,7 @@ function normalizeWorkspaces(data) {
 
   const notes = data.notes.map((n) => ({
     ...n,
-    workspaceId: ids.has(n.workspaceId) ? n.workspaceId : fallbackId,
+    workspaceId: ids.has(n.workspaceId) ? n.workspaceId : fallbackId
   }));
 
   const requested = data.settings?.activeWorkspace;
@@ -189,10 +166,10 @@ function normalizeWorkspaces(data) {
       ...data.settings,
       activeWorkspace: ids.has(requested) ? requested : fallbackId,
       theme: sanitizeTheme(data.settings?.theme),
-      accent: sanitizeAccent(data.settings?.accent),
+      accent: sanitizeAccent(data.settings?.accent)
     },
     workspaces,
-    notes,
+    notes
   };
 }
 
@@ -203,7 +180,7 @@ function normalizeWorkspaces(data) {
 // v5 is the `images` schema from #9, accepted here as a migration source too,
 // so this change and that one are independent of merge order.
 function migrate(data) {
-  if (!data || typeof data !== "object") return emptyStore();
+  if (!data || typeof data !== 'object') return emptyStore();
   if (!Array.isArray(data.notes)) return emptyStore();
 
   // Drop entries that are not objects before anything reads fields off them.
@@ -212,14 +189,12 @@ function migrate(data) {
   // dereferences each entry. Reading `n.monospace` off a null throws, and the
   // throw escapes _load's JSON.parse try block, so it would surface as a
   // crash on launch rather than the corrupt-file recovery path.
-  const sourceNotes = data.notes.filter((n) => n && typeof n === "object");
+  const sourceNotes = data.notes.filter((n) => n && typeof n === 'object');
 
   let notes;
   if (!data.version) {
     // v1 -> current: add visible/title/displayId/pinned/monospace/timestamps.
-    notes = sourceNotes.map((n) =>
-      defaultRecord({ ...n, visible: true, pinned: true }),
-    );
+    notes = sourceNotes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }));
   } else if (data.version === 2) {
     // v2 -> current: backfill pinned:true so existing notes keep today's
     // always-on-top behavior unchanged. Monospace defaults to off unless
@@ -227,7 +202,7 @@ function migrate(data) {
     notes = sourceNotes.map((n) => ({
       ...n,
       pinned: n.pinned !== undefined ? !!n.pinned : true,
-      monospace: !!n.monospace,
+      monospace: !!n.monospace
     }));
   } else if (data.version === 3 || data.version === 4 || data.version === 5) {
     // v3 -> v4: existing notes stay proportional unless the user toggles {}.
@@ -251,22 +226,16 @@ function migrate(data) {
 // fields are dropped by defaultRecord(), and duplicate ids are skipped.
 // Returns null when the payload is not a notes file at all.
 function normalizeImport(data) {
-  if (!data || typeof data !== "object" || !Array.isArray(data.notes))
-    return null;
+  if (!data || typeof data !== 'object' || !Array.isArray(data.notes)) return null;
   // An empty array is intentionally importable (so "Replace" can clear notes),
   // but that means any random JSON with notes: [] would otherwise pass. Exports
   // always write the app marker and a numeric version, so require one of those
   // when there is nothing else to look at.
-  if (
-    data.notes.length === 0 &&
-    data.app !== "ghost-notes" &&
-    !Number.isFinite(data.version)
-  )
-    return null;
+  if (data.notes.length === 0 && data.app !== 'ghost-notes' && !Number.isFinite(data.version)) return null;
   const seen = new Set();
   const notes = [];
   for (const entry of migrate(data).notes) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
     // defaultRecord() uses overrides.createdAt || Date.now(), so a valid epoch
     // timestamp of 0 would be overwritten before the checks below run. Capture
     // the raw values and restore them when they are actually finite.
@@ -275,26 +244,19 @@ function normalizeImport(data) {
     const record = defaultRecord(entry);
     if (Number.isFinite(rawCreatedAt)) record.createdAt = rawCreatedAt;
     if (Number.isFinite(rawUpdatedAt)) record.updatedAt = rawUpdatedAt;
-    if (typeof record.id !== "string" || !record.id) record.id = nextId();
+    if (typeof record.id !== 'string' || !record.id) record.id = nextId();
     if (seen.has(record.id)) continue;
     seen.add(record.id);
-    if (typeof record.title !== "string") record.title = "";
-    if (typeof record.text !== "string") record.text = "";
-    if (typeof record.color !== "string") record.color = "yellow";
+    if (typeof record.title !== 'string') record.title = '';
+    if (typeof record.text !== 'string') record.text = '';
+    if (typeof record.color !== 'string') record.color = 'yellow';
     // typeof alone lets NaN/Infinity through; only finite numbers are valid
     // for sizes, positions and timestamps. width/height/opacity also get
     // bounds so a bad backup can't produce an unusable window.
-    if (
-      !Number.isFinite(record.opacity) ||
-      record.opacity <= 0 ||
-      record.opacity > 1
-    )
-      record.opacity = 0.85;
+    if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
-    if (!Number.isFinite(record.width) || record.width < 160)
-      record.width = 300;
-    if (!Number.isFinite(record.height) || record.height < 120)
-      record.height = 220;
+    if (!Number.isFinite(record.width) || record.width < 160) record.width = 300;
+    if (!Number.isFinite(record.height) || record.height < 120) record.height = 220;
     if (!Number.isFinite(record.x)) record.x = undefined;
     if (!Number.isFinite(record.y)) record.y = undefined;
     if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();
@@ -315,9 +277,9 @@ class NoteStore {
   // When omitted (e.g. OS-level encryption unavailable), notes are stored as
   // plaintext — matching the original behavior.
   constructor(userDataPath, { onCorrupted, onWriteError, codec } = {}) {
-    this.filePath = path.join(userDataPath, "notes.json");
-    this.tmpPath = this.filePath + ".tmp";
-    this.backupPath = this.filePath + ".corrupt";
+    this.filePath = path.join(userDataPath, 'notes.json');
+    this.tmpPath = this.filePath + '.tmp';
+    this.backupPath = this.filePath + '.corrupt';
     this.onCorrupted = onCorrupted;
     this.onWriteError = onWriteError;
     this.codec = codec || null;
@@ -361,7 +323,7 @@ class NoteStore {
     // 2) Legacy plaintext JSON (or an unreadable/corrupted file).
     let parsed = null;
     try {
-      parsed = JSON.parse(raw.toString("utf8"));
+      parsed = JSON.parse(raw.toString('utf8'));
     } catch (_) {
       return { data: this._corrupt(raw), migrated: false };
     }
@@ -373,10 +335,7 @@ class NoteStore {
       // About to run a schema migration — snapshot the pre-migration file
       // first so a bug in migrate() can never be the only copy of the data.
       try {
-        fs.writeFileSync(
-          this.filePath + `.pre-migration-v${(parsed && parsed.version) || 1}`,
-          raw,
-        );
+        fs.writeFileSync(this.filePath + `.pre-migration-v${(parsed && parsed.version) || 1}`, raw);
       } catch (_) {}
     }
     return migrate(parsed);
@@ -388,7 +347,7 @@ class NoteStore {
     try {
       fs.writeFileSync(this.backupPath, raw);
     } catch (_) {}
-    console.error("notes.json was corrupted, backed up to", this.backupPath);
+    console.error('notes.json was corrupted, backed up to', this.backupPath);
     if (this.onCorrupted) this.onCorrupted(this.backupPath);
     return emptyStore();
   }
@@ -399,13 +358,13 @@ class NoteStore {
       // safeStorage.encryptString returns a Buffer; write it as-is.
       out = this.codec.encrypt(JSON.stringify(this.data));
     } else {
-      out = Buffer.from(JSON.stringify(this.data, null, 2), "utf8");
+      out = Buffer.from(JSON.stringify(this.data, null, 2), 'utf8');
     }
     try {
       fs.writeFileSync(this.tmpPath, out);
       fs.renameSync(this.tmpPath, this.filePath);
     } catch (e) {
-      console.error("Failed to save notes:", e);
+      console.error('Failed to save notes:', e);
       if (this.onWriteError) this.onWriteError(e);
     }
   }
@@ -441,7 +400,7 @@ class NoteStore {
     // unless the caller is explicit about it.
     const record = defaultRecord({
       workspaceId: this.activeWorkspaceId(),
-      ...overrides,
+      ...overrides
     });
     this.data.notes.push(record);
     this.save();
@@ -609,5 +568,5 @@ module.exports = {
   THEME_MODES,
   ACCENT_IDS,
   DEFAULT_THEME,
-  DEFAULT_ACCENT,
+  DEFAULT_ACCENT
 };

--- a/store.js
+++ b/store.js
@@ -1,8 +1,8 @@
 // Persistence layer: versioned, atomic-write JSON store for note records.
 // A "record" is the durable note (id, content, position, visible flag) —
 // independent of whether a BrowserWindow currently exists for it.
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 const STORE_VERSION = 6;
 
@@ -15,23 +15,51 @@ const STORE_VERSION = 6;
 // "Personal" should not be stuck with an unused "Default" forever. The
 // invariant that actually holds is that at least one workspace always exists,
 // so pickFallbackWorkspace() always has a destination.
-const DEFAULT_WORKSPACE_ID = 'ws-default';
-const DEFAULT_WORKSPACE_NAME = 'Default';
+const DEFAULT_WORKSPACE_ID = "ws-default";
+const DEFAULT_WORKSPACE_NAME = "Default";
 const MAX_WORKSPACE_NAME_LENGTH = 40;
 
+// Appearance preferences (Manager-only theming). Note bodies keep their
+// per-note color; theme/accent only restyle Manager chrome.
+const THEME_MODES = ["light", "dark", "system"];
+const DEFAULT_THEME = "system";
+const ACCENT_IDS = ["violet", "blue", "green", "orange", "pink"];
+const DEFAULT_ACCENT = "violet";
+
+function sanitizeTheme(input) {
+  return THEME_MODES.includes(input) ? input : DEFAULT_THEME;
+}
+
+function sanitizeAccent(input) {
+  return ACCENT_IDS.includes(input) ? input : DEFAULT_ACCENT;
+}
+
 function nextId() {
-  return 'note-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+  return (
+    "note-" +
+    Date.now().toString(36) +
+    "-" +
+    Math.random().toString(36).slice(2, 6)
+  );
 }
 
 function nextWorkspaceId() {
-  return 'ws-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6);
+  return (
+    "ws-" +
+    Date.now().toString(36) +
+    "-" +
+    Math.random().toString(36).slice(2, 6)
+  );
 }
 
 // Workspace names are shown in a tray menu, where a newline or an
 // over-long string would break the layout, so normalize at the boundary.
 function sanitizeWorkspaceName(input) {
-  if (typeof input !== 'string') return '';
-  return input.replace(/[\r\n]+/g, ' ').trim().slice(0, MAX_WORKSPACE_NAME_LENGTH);
+  if (typeof input !== "string") return "";
+  return input
+    .replace(/[\r\n]+/g, " ")
+    .trim()
+    .slice(0, MAX_WORKSPACE_NAME_LENGTH);
 }
 
 function defaultWorkspace(overrides = {}) {
@@ -39,11 +67,11 @@ function defaultWorkspace(overrides = {}) {
   // replaced rather than stored. Notes still pointing at the old value are
   // reattached by normalizeWorkspaces, which reassigns any workspaceId that
   // does not match a workspace that exists.
-  const id = typeof overrides.id === 'string' ? overrides.id.trim() : '';
+  const id = typeof overrides.id === "string" ? overrides.id.trim() : "";
   return {
     id: id || nextWorkspaceId(),
-    name: sanitizeWorkspaceName(overrides.name) || 'Untitled workspace',
-    createdAt: overrides.createdAt || Date.now()
+    name: sanitizeWorkspaceName(overrides.name) || "Untitled workspace",
+    createdAt: overrides.createdAt || Date.now(),
   };
 }
 
@@ -51,15 +79,15 @@ function defaultRecord(overrides = {}) {
   const now = overrides.createdAt || Date.now();
   return {
     id: overrides.id || nextId(),
-    title: overrides.title || '',
-    text: overrides.text || '',
-    color: overrides.color || 'yellow',
+    title: overrides.title || "",
+    text: overrides.text || "",
+    color: overrides.color || "yellow",
     x: overrides.x,
     y: overrides.y,
     width: overrides.width || 300,
     height: overrides.height || 220,
     displayId: overrides.displayId ?? null,
-    opacity: typeof overrides.opacity === 'number' ? overrides.opacity : 0.85,
+    opacity: typeof overrides.opacity === "number" ? overrides.opacity : 0.85,
     fontSize: overrides.fontSize || 15,
     // Per-note monospace toggle for code walkthroughs (issue #7).
     monospace: !!overrides.monospace,
@@ -72,7 +100,7 @@ function defaultRecord(overrides = {}) {
     // Unpinned = a normal window that can be covered by whatever's focused.
     pinned: overrides.pinned !== undefined ? !!overrides.pinned : true,
     createdAt: now,
-    updatedAt: overrides.updatedAt || now
+    updatedAt: overrides.updatedAt || now,
   };
 }
 
@@ -82,20 +110,29 @@ function defaultRecord(overrides = {}) {
 // than assuming it is "Default", which is wrong once that workspace has been
 // renamed or deleted. Returns null only for an empty list.
 function pickFallbackWorkspace(workspaces, excludeId) {
-  const remaining = excludeId === undefined ? workspaces : workspaces.filter((w) => w.id !== excludeId);
-  return remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0] || null;
+  const remaining =
+    excludeId === undefined
+      ? workspaces
+      : workspaces.filter((w) => w.id !== excludeId);
+  return (
+    remaining.find((w) => w.id === DEFAULT_WORKSPACE_ID) || remaining[0] || null
+  );
 }
 
 function emptyStore() {
   const workspace = defaultWorkspace({
     id: DEFAULT_WORKSPACE_ID,
-    name: DEFAULT_WORKSPACE_NAME
+    name: DEFAULT_WORKSPACE_NAME,
   });
   return {
     version: STORE_VERSION,
-    settings: { activeWorkspace: workspace.id },
+    settings: {
+      activeWorkspace: workspace.id,
+      theme: DEFAULT_THEME,
+      accent: DEFAULT_ACCENT,
+    },
     workspaces: [workspace],
-    notes: []
+    notes: [],
   };
 }
 
@@ -118,7 +155,7 @@ function normalizeWorkspaces(data) {
   const seenIds = new Set();
   let workspaces = [];
   for (const entry of Array.isArray(data.workspaces) ? data.workspaces : []) {
-    if (!entry || typeof entry !== 'object') continue;
+    if (!entry || typeof entry !== "object") continue;
     const workspace = defaultWorkspace(entry);
     if (seenIds.has(workspace.id)) continue;
     seenIds.add(workspace.id);
@@ -126,7 +163,12 @@ function normalizeWorkspaces(data) {
   }
 
   if (workspaces.length === 0) {
-    workspaces = [defaultWorkspace({ id: DEFAULT_WORKSPACE_ID, name: DEFAULT_WORKSPACE_NAME })];
+    workspaces = [
+      defaultWorkspace({
+        id: DEFAULT_WORKSPACE_ID,
+        name: DEFAULT_WORKSPACE_NAME,
+      }),
+    ];
   }
 
   const ids = new Set(workspaces.map((w) => w.id));
@@ -134,17 +176,23 @@ function normalizeWorkspaces(data) {
 
   const notes = data.notes.map((n) => ({
     ...n,
-    workspaceId: ids.has(n.workspaceId) ? n.workspaceId : fallbackId
+    workspaceId: ids.has(n.workspaceId) ? n.workspaceId : fallbackId,
   }));
 
   const requested = data.settings?.activeWorkspace;
   return {
     version: STORE_VERSION,
-    // Spread first so future app-level settings (theme in #2, custom
-    // shortcuts in #5) survive a workspace migration untouched.
-    settings: { ...data.settings, activeWorkspace: ids.has(requested) ? requested : fallbackId },
+    // Spread first so future app-level settings (custom shortcuts in #5)
+    // survive a workspace migration untouched. Theme/accent are re-sanitized
+    // so a hand-edited value can never break the UI.
+    settings: {
+      ...data.settings,
+      activeWorkspace: ids.has(requested) ? requested : fallbackId,
+      theme: sanitizeTheme(data.settings?.theme),
+      accent: sanitizeAccent(data.settings?.accent),
+    },
     workspaces,
-    notes
+    notes,
   };
 }
 
@@ -155,7 +203,7 @@ function normalizeWorkspaces(data) {
 // v5 is the `images` schema from #9, accepted here as a migration source too,
 // so this change and that one are independent of merge order.
 function migrate(data) {
-  if (!data || typeof data !== 'object') return emptyStore();
+  if (!data || typeof data !== "object") return emptyStore();
   if (!Array.isArray(data.notes)) return emptyStore();
 
   // Drop entries that are not objects before anything reads fields off them.
@@ -164,12 +212,14 @@ function migrate(data) {
   // dereferences each entry. Reading `n.monospace` off a null throws, and the
   // throw escapes _load's JSON.parse try block, so it would surface as a
   // crash on launch rather than the corrupt-file recovery path.
-  const sourceNotes = data.notes.filter((n) => n && typeof n === 'object');
+  const sourceNotes = data.notes.filter((n) => n && typeof n === "object");
 
   let notes;
   if (!data.version) {
     // v1 -> current: add visible/title/displayId/pinned/monospace/timestamps.
-    notes = sourceNotes.map((n) => defaultRecord({ ...n, visible: true, pinned: true }));
+    notes = sourceNotes.map((n) =>
+      defaultRecord({ ...n, visible: true, pinned: true }),
+    );
   } else if (data.version === 2) {
     // v2 -> current: backfill pinned:true so existing notes keep today's
     // always-on-top behavior unchanged. Monospace defaults to off unless
@@ -177,7 +227,7 @@ function migrate(data) {
     notes = sourceNotes.map((n) => ({
       ...n,
       pinned: n.pinned !== undefined ? !!n.pinned : true,
-      monospace: !!n.monospace
+      monospace: !!n.monospace,
     }));
   } else if (data.version === 3 || data.version === 4 || data.version === 5) {
     // v3 -> v4: existing notes stay proportional unless the user toggles {}.
@@ -201,16 +251,22 @@ function migrate(data) {
 // fields are dropped by defaultRecord(), and duplicate ids are skipped.
 // Returns null when the payload is not a notes file at all.
 function normalizeImport(data) {
-  if (!data || typeof data !== 'object' || !Array.isArray(data.notes)) return null;
+  if (!data || typeof data !== "object" || !Array.isArray(data.notes))
+    return null;
   // An empty array is intentionally importable (so "Replace" can clear notes),
   // but that means any random JSON with notes: [] would otherwise pass. Exports
   // always write the app marker and a numeric version, so require one of those
   // when there is nothing else to look at.
-  if (data.notes.length === 0 && data.app !== 'ghost-notes' && !Number.isFinite(data.version)) return null;
+  if (
+    data.notes.length === 0 &&
+    data.app !== "ghost-notes" &&
+    !Number.isFinite(data.version)
+  )
+    return null;
   const seen = new Set();
   const notes = [];
   for (const entry of migrate(data).notes) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
     // defaultRecord() uses overrides.createdAt || Date.now(), so a valid epoch
     // timestamp of 0 would be overwritten before the checks below run. Capture
     // the raw values and restore them when they are actually finite.
@@ -219,19 +275,26 @@ function normalizeImport(data) {
     const record = defaultRecord(entry);
     if (Number.isFinite(rawCreatedAt)) record.createdAt = rawCreatedAt;
     if (Number.isFinite(rawUpdatedAt)) record.updatedAt = rawUpdatedAt;
-    if (typeof record.id !== 'string' || !record.id) record.id = nextId();
+    if (typeof record.id !== "string" || !record.id) record.id = nextId();
     if (seen.has(record.id)) continue;
     seen.add(record.id);
-    if (typeof record.title !== 'string') record.title = '';
-    if (typeof record.text !== 'string') record.text = '';
-    if (typeof record.color !== 'string') record.color = 'yellow';
+    if (typeof record.title !== "string") record.title = "";
+    if (typeof record.text !== "string") record.text = "";
+    if (typeof record.color !== "string") record.color = "yellow";
     // typeof alone lets NaN/Infinity through; only finite numbers are valid
     // for sizes, positions and timestamps. width/height/opacity also get
     // bounds so a bad backup can't produce an unusable window.
-    if (!Number.isFinite(record.opacity) || record.opacity <= 0 || record.opacity > 1) record.opacity = 0.85;
+    if (
+      !Number.isFinite(record.opacity) ||
+      record.opacity <= 0 ||
+      record.opacity > 1
+    )
+      record.opacity = 0.85;
     if (!Number.isFinite(record.fontSize)) record.fontSize = 15;
-    if (!Number.isFinite(record.width) || record.width < 160) record.width = 300;
-    if (!Number.isFinite(record.height) || record.height < 120) record.height = 220;
+    if (!Number.isFinite(record.width) || record.width < 160)
+      record.width = 300;
+    if (!Number.isFinite(record.height) || record.height < 120)
+      record.height = 220;
     if (!Number.isFinite(record.x)) record.x = undefined;
     if (!Number.isFinite(record.y)) record.y = undefined;
     if (!Number.isFinite(record.createdAt)) record.createdAt = Date.now();
@@ -252,9 +315,9 @@ class NoteStore {
   // When omitted (e.g. OS-level encryption unavailable), notes are stored as
   // plaintext — matching the original behavior.
   constructor(userDataPath, { onCorrupted, onWriteError, codec } = {}) {
-    this.filePath = path.join(userDataPath, 'notes.json');
-    this.tmpPath = this.filePath + '.tmp';
-    this.backupPath = this.filePath + '.corrupt';
+    this.filePath = path.join(userDataPath, "notes.json");
+    this.tmpPath = this.filePath + ".tmp";
+    this.backupPath = this.filePath + ".corrupt";
     this.onCorrupted = onCorrupted;
     this.onWriteError = onWriteError;
     this.codec = codec || null;
@@ -298,7 +361,7 @@ class NoteStore {
     // 2) Legacy plaintext JSON (or an unreadable/corrupted file).
     let parsed = null;
     try {
-      parsed = JSON.parse(raw.toString('utf8'));
+      parsed = JSON.parse(raw.toString("utf8"));
     } catch (_) {
       return { data: this._corrupt(raw), migrated: false };
     }
@@ -310,7 +373,10 @@ class NoteStore {
       // About to run a schema migration — snapshot the pre-migration file
       // first so a bug in migrate() can never be the only copy of the data.
       try {
-        fs.writeFileSync(this.filePath + `.pre-migration-v${(parsed && parsed.version) || 1}`, raw);
+        fs.writeFileSync(
+          this.filePath + `.pre-migration-v${(parsed && parsed.version) || 1}`,
+          raw,
+        );
       } catch (_) {}
     }
     return migrate(parsed);
@@ -322,7 +388,7 @@ class NoteStore {
     try {
       fs.writeFileSync(this.backupPath, raw);
     } catch (_) {}
-    console.error('notes.json was corrupted, backed up to', this.backupPath);
+    console.error("notes.json was corrupted, backed up to", this.backupPath);
     if (this.onCorrupted) this.onCorrupted(this.backupPath);
     return emptyStore();
   }
@@ -333,13 +399,13 @@ class NoteStore {
       // safeStorage.encryptString returns a Buffer; write it as-is.
       out = this.codec.encrypt(JSON.stringify(this.data));
     } else {
-      out = Buffer.from(JSON.stringify(this.data, null, 2), 'utf8');
+      out = Buffer.from(JSON.stringify(this.data, null, 2), "utf8");
     }
     try {
       fs.writeFileSync(this.tmpPath, out);
       fs.renameSync(this.tmpPath, this.filePath);
     } catch (e) {
-      console.error('Failed to save notes:', e);
+      console.error("Failed to save notes:", e);
       if (this.onWriteError) this.onWriteError(e);
     }
   }
@@ -375,7 +441,7 @@ class NoteStore {
     // unless the caller is explicit about it.
     const record = defaultRecord({
       workspaceId: this.activeWorkspaceId(),
-      ...overrides
+      ...overrides,
     });
     this.data.notes.push(record);
     this.save();
@@ -410,6 +476,31 @@ class NoteStore {
 
   settings() {
     return this.data.settings;
+  }
+
+  // ---------- Appearance (Manager-only theme + accent) ----------
+  getTheme() {
+    return sanitizeTheme(this.data.settings.theme);
+  }
+
+  setTheme(mode) {
+    const clean = sanitizeTheme(mode);
+    if (this.data.settings.theme === clean) return clean;
+    this.data.settings.theme = clean;
+    this.save();
+    return clean;
+  }
+
+  getAccent() {
+    return sanitizeAccent(this.data.settings.accent);
+  }
+
+  setAccent(id) {
+    const clean = sanitizeAccent(id);
+    if (this.data.settings.accent === clean) return clean;
+    this.data.settings.accent = clean;
+    this.save();
+    return clean;
   }
 
   workspaces() {
@@ -512,5 +603,11 @@ module.exports = {
   normalizeImport,
   STORE_VERSION,
   DEFAULT_WORKSPACE_ID,
-  sanitizeWorkspaceName
+  sanitizeWorkspaceName,
+  sanitizeTheme,
+  sanitizeAccent,
+  THEME_MODES,
+  ACCENT_IDS,
+  DEFAULT_THEME,
+  DEFAULT_ACCENT,
 };

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -94,6 +94,44 @@ test('keeps settings keys it does not know about', () => {
   assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
 });
 
+test('fresh install defaults to system theme and violet accent', () => {
+  const store = freshStore();
+  assert.equal(store.getTheme(), 'system');
+  assert.equal(store.getAccent(), 'violet');
+});
+
+test('sanitizes invalid theme and accent values on load', () => {
+  const store = freshStore({
+    version: STORE_VERSION,
+    settings: { activeWorkspace: DEFAULT_WORKSPACE_ID, theme: 'neon', accent: '#fff' },
+    workspaces: [{ id: DEFAULT_WORKSPACE_ID, name: 'D' }],
+    notes: []
+  });
+  assert.equal(store.getTheme(), 'system');
+  assert.equal(store.getAccent(), 'violet');
+});
+
+test('setTheme and setAccent persist across reload', () => {
+  const dir = storeDir();
+  const first = openStore(dir);
+  first.setTheme('dark');
+  first.setAccent('blue');
+  first.flush();
+
+  const second = openStore(dir);
+  assert.equal(second.getTheme(), 'dark');
+  assert.equal(second.getAccent(), 'blue');
+});
+
+test('import replace preserves theme and accent', () => {
+  const store = freshStore();
+  store.setTheme('light');
+  store.setAccent('green');
+  store.replaceAll([{ id: 'a', text: 'x', workspaceId: DEFAULT_WORKSPACE_ID }]);
+  assert.equal(store.getTheme(), 'light');
+  assert.equal(store.getAccent(), 'green');
+});
+
 test('repairs notes and an active workspace pointing at a workspace that is gone', () => {
   const store = freshStore({
     version: STORE_VERSION,


### PR DESCRIPTION
## Description

- added theme support with light/dark/system options
- added accent colour options as well

## Related Issue

Closes #2

## Changes Made

<!-- Briefly list what you changed. -->
- `store.js` — added `theme` (light/dark/system) + `accent` (5 presets) to settings with sanitizers and getters/setters; no version bump.
- `main.js` — owns `nativeTheme`, resolves `effectiveDark`, live-updates on OS change.
- `manager.js` / `manager-preload.js` — theme/accent ride the manager snapshot; added `setTheme`/`setAccent` channels.
- `manager.html` / `manager-renderer.js` — Appearance bar with theme switch + accent dots; dark mode via `data-theme`. Notes untouched.
- `test/store.test.js` — 4 new tests for defaults, sanitization, and persistence.

## Testing

<!-- How did you test this? What OS did you test on? -->

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux (if applicable)

**Steps to reproduce / verify:**
1. npm start → open Notes Manager → find the Appearance bar.
2. Switch Light / Dark / System
3. Pick each accent dot
4. With System selected, flip the OS light/dark mode

## Screenshots / Recordings (if applicable)

https://github.com/user-attachments/assets/39111693-2cbf-4b5e-81d6-06c98c7c5eb1

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused — this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`
