### PR TITLE
feat(shortcuts): customizable global shortcuts (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ The app lives in the **menu bar / system tray** (no Dock icon on macOS). A note 
 - **Click-through mode:** the ghost icon (👻) in the hover bar — clicks pass through to whatever is behind the note; hover the bar to interact again
 - **Close a note:** ✕ in the hover bar — this **hides** the note, it does not delete it. The note stays in the Notes Manager and can be reopened any time.
 - **Delete a note permanently:** only from the Notes Manager, with a confirmation prompt.
-- **Keyboard shortcuts list:** tray icon → Keyboard Shortcuts…, or the **?** button in the Notes Manager — every active shortcut, written the way your platform writes it
+- **Keyboard shortcuts list & customization:** tray icon → Keyboard Shortcuts…, or the **?** button in the Notes Manager — view every active shortcut, customize keybindings by clicking the edit icon on any row, or reset to defaults at any time.
 - **Backup / migrate notes:** the download/upload buttons in the Notes Manager toolbar. "Export All Notes" writes every note to a plain JSON backup file (the file itself is not encrypted — keep it somewhere safe); "Import Notes" restores a backup, either merging it with your current notes or replacing them.
 - **Quit:** tray icon → Quit
 
-The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden. You never have to come back here to look any of this up — the in-app list under **Keyboard Shortcuts…** shows the same thing.
+The standard keyboard shortcuts work while a Ghost Notes note or the Notes Manager has focus. They stay inactive in other apps, so the same shortcuts remain available to your browser, IDE, and operating system. The three-modifier new-note shortcut is the only global binding, providing a way back into the app when every Ghost Notes window is hidden. You never have to come back here to look any of this up — the in-app list under **Keyboard Shortcuts…** shows the same thing and lets you rebind them.
 
 Notes (text, position, size, color, opacity, open/hidden state) auto-save and reappear on next launch. Data lives in a single local JSON file in the OS app-data folder — never uploaded anywhere.
 

--- a/main.js
+++ b/main.js
@@ -19,7 +19,8 @@ const {
   registerShortcuts,
   registerFallbackShortcut,
   unregisterFallbackShortcut,
-  getShortcuts
+  getShortcuts,
+  applyOverrides
 } = require('./shortcuts');
 const { createManagerModule } = require('./manager');
 
@@ -98,7 +99,12 @@ function createManager() {
       renameWorkspace: (id, name) => renameWorkspace(id, name),
       removeWorkspace: (id) => removeWorkspace(id),
       moveNoteToWorkspace: (noteId, workspaceId) => moveNoteToWorkspace(noteId, workspaceId),
-      importNotes: (records, mode) => importNotes(records, mode)
+      importNotes: (records, mode) => importNotes(records, mode),
+      onShortcutsUpdated: () => {
+        unregisterFallbackShortcut(globalShortcut);
+        registerFallbackShortcut(globalShortcut, () => createNoteNearCursor());
+        updateTrayMenu();
+      }
     }
   });
 }
@@ -536,6 +542,7 @@ if (!gotLock) {
     // is the earliest safe point to construct the (synchronous) store and wire
     // up the manager that depends on it.
     store = createStore();
+    applyOverrides(store.getShortcutOverrides());
     manager = createManager();
 
     setupTray();

--- a/manager-preload.js
+++ b/manager-preload.js
@@ -9,8 +9,10 @@ contextBridge.exposeInMainWorld('manager', {
   newNote: () => ipcRenderer.send('manager:new'),
   onChanged: (cb) => ipcRenderer.on('manager:notesChanged', (e, snapshot) => cb(snapshot)),
   version: () => ipcRenderer.invoke('manager:version'),
-  // Shortcut legend (issue #20)
+  // Shortcut legend (issue #20) and customizable shortcuts (issue #5)
   shortcuts: () => ipcRenderer.invoke('manager:shortcuts'),
+  setShortcut: (id, accelerator) => ipcRenderer.invoke('manager:setShortcut', { id, accelerator }),
+  resetShortcut: (id) => ipcRenderer.invoke('manager:resetShortcut', id),
   onShowShortcuts: (cb) => ipcRenderer.on('manager:showShortcuts', () => cb()),
   // Workspaces (issue #8)
   setWorkspace: (id) => ipcRenderer.send('manager:setWorkspace', id),

--- a/manager-renderer.js
+++ b/manager-renderer.js
@@ -12,7 +12,8 @@ const ICONS = {
   eyeOff: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24M1 1l22 22"/></svg>',
   trash: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0-1 14a2 2 0 01-2 2H7a2 2 0 01-2-2L4 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>',
   notes: '<svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h12l4 4v12H4z"/><path d="M16 4v4h4"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="8" y1="16" x2="13" y2="16"/></svg>',
-  move: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h6"/><path d="m17 15 3 3-3 3"/><path d="M13 18h7"/></svg>'
+  move: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h6"/><path d="m17 15 3 3-3 3"/><path d="M13 18h7"/></svg>',
+  edit: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>'
 };
 
 const listEl = document.getElementById('list');
@@ -318,6 +319,98 @@ function shortcutDisplay(id) {
   return match ? match.display : '';
 }
 
+let recordingShortcutId = null;
+let recordingCleanup = null;
+
+function cancelRecording() {
+  if (recordingCleanup) {
+    recordingCleanup();
+    recordingCleanup = null;
+  }
+  recordingShortcutId = null;
+  renderShortcuts(shortcuts);
+}
+
+function electronKeyFromEvent(e) {
+  // If it's only a modifier key, return null so we wait for the actual non-modifier key
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return null;
+
+  // Key codes and names
+  let key = e.key;
+  if (e.code && e.code.startsWith('Key')) {
+    key = e.code.slice(3).toUpperCase();
+  } else if (e.code && e.code.startsWith('Digit')) {
+    key = e.code.slice(5);
+  } else if (key.length === 1) {
+    key = key.toUpperCase();
+  }
+
+  return key;
+}
+
+function startRecording(shortcut, kbdEl) {
+  if (recordingShortcutId === shortcut.id) {
+    cancelRecording();
+    return;
+  }
+  if (recordingShortcutId) {
+    cancelRecording();
+  }
+
+  recordingShortcutId = shortcut.id;
+  kbdEl.classList.add('kbd-recording');
+  kbdEl.textContent = 'Press keys…';
+
+  const onKeyDown = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.key === 'Escape') {
+      cancelRecording();
+      return;
+    }
+
+    const key = electronKeyFromEvent(e);
+    if (!key) return; // Modifier pressed alone, wait for companion key
+
+    // Build the accelerator.
+    // For app-scoped shortcuts: app matcher expects CommandOrControl + Shift + Key.
+    // For global shortcuts: CommandOrControl + Alt + Shift + Key or custom modifiers.
+    const parts = [];
+    if (e.ctrlKey || e.metaKey) {
+      parts.push('CommandOrControl');
+    }
+    if (shortcut.scope === 'global') {
+      if (e.altKey) parts.push('Alt');
+      if (e.shiftKey) parts.push('Shift');
+      // If user didn't press CommandOrControl or Alt, require at least CommandOrControl
+      if (!parts.includes('CommandOrControl') && !parts.includes('Alt')) {
+        parts.unshift('CommandOrControl');
+      }
+    } else {
+      // App-scoped shortcuts: require CommandOrControl+Shift
+      if (!parts.includes('CommandOrControl')) parts.push('CommandOrControl');
+      if (!parts.includes('Shift')) parts.push('Shift');
+    }
+
+    parts.push(key);
+    const newAccelerator = parts.join('+');
+
+    cancelRecording();
+    const updated = await window.manager.setShortcut(shortcut.id, newAccelerator);
+    if (Array.isArray(updated)) {
+      shortcuts = updated;
+      renderShortcuts(shortcuts);
+      render();
+    }
+  };
+
+  document.addEventListener('keydown', onKeyDown, { capture: true });
+  recordingCleanup = () => {
+    document.removeEventListener('keydown', onKeyDown, { capture: true });
+  };
+}
+
 function shortcutRow(shortcut) {
   const row = document.createElement('div');
   row.className = 'sc-row';
@@ -338,10 +431,48 @@ function shortcutRow(shortcut) {
 
   const keys = document.createElement('kbd');
   keys.className = 'sc-keys';
-  keys.textContent = shortcut.display;
+  if (recordingShortcutId === shortcut.id) {
+    keys.classList.add('kbd-recording');
+    keys.textContent = 'Press keys…';
+  } else {
+    keys.textContent = shortcut.display;
+  }
+
+  const actionsEl = document.createElement('div');
+  actionsEl.className = 'sc-actions';
+
+  if (shortcut.isCustom) {
+    const resetBtn = document.createElement('button');
+    resetBtn.className = 'sc-reset-btn';
+    resetBtn.textContent = 'Reset';
+    resetBtn.title = 'Reset to default';
+    resetBtn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      cancelRecording();
+      const updated = await window.manager.resetShortcut(shortcut.id);
+      if (Array.isArray(updated)) {
+        shortcuts = updated;
+        renderShortcuts(shortcuts);
+        render();
+      }
+    });
+    actionsEl.appendChild(resetBtn);
+  }
+
+  const editBtn = document.createElement('button');
+  editBtn.className = 'icon-btn sc-edit-btn';
+  editBtn.title = recordingShortcutId === shortcut.id ? 'Cancel recording' : 'Change shortcut';
+  editBtn.setAttribute('aria-label', `Change shortcut for ${shortcut.label}`);
+  editBtn.innerHTML = ICONS.edit;
+  editBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    startRecording(shortcut, keys);
+  });
+  actionsEl.appendChild(editBtn);
 
   row.appendChild(text);
   row.appendChild(keys);
+  row.appendChild(actionsEl);
   return row;
 }
 
@@ -403,6 +534,7 @@ async function openShortcuts() {
 }
 
 function closeShortcuts() {
+  cancelRecording();
   if (shortcutsEl.hidden) return;
   for (const el of behindTheSheet) el.inert = false;
   shortcutsEl.hidden = true;

--- a/manager.html
+++ b/manager.html
@@ -482,6 +482,45 @@
     border-radius: 6px;
     padding: 4px 8px;
     white-space: nowrap;
+    transition: border-color 0.15s, box-shadow 0.15s, background-color 0.15s;
+  }
+  .sc-keys.kbd-recording {
+    background: var(--accent-lt);
+    color: var(--accent-dk);
+    border-color: var(--accent);
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    animation: pulse-recording 1.2s infinite ease-in-out;
+  }
+  @keyframes pulse-recording {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.6; }
+  }
+  .sc-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 0 0 auto;
+  }
+  .sc-reset-btn {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .sc-reset-btn:hover {
+    color: var(--ink);
+    background: var(--surface-2);
+  }
+  .sc-reset-btn:focus-visible,
+  .sc-edit-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   #status {
     color: var(--accent-dk);

--- a/manager.js
+++ b/manager.js
@@ -5,7 +5,7 @@
 const path = require('path');
 const fs = require('fs');
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
-const { registerShortcuts, getShortcuts } = require('./shortcuts');
+const { registerShortcuts, getShortcuts, applyOverrides } = require('./shortcuts');
 const { sanitizeWorkspaceName, STORE_VERSION, normalizeImport } = require('./store');
 
 const MAX_TITLE_LENGTH = 80;
@@ -81,7 +81,34 @@ function createManagerModule({ store, actions }) {
 
   ipcMain.handle('manager:list', () => snapshot());
   ipcMain.handle('manager:version', () => app.getVersion());
-  ipcMain.handle('manager:shortcuts', () => getShortcuts());
+  ipcMain.handle('manager:shortcuts', () => getShortcuts(store.getShortcutOverrides()));
+
+  ipcMain.handle('manager:setShortcut', (e, payload) => {
+    if (!payload || typeof payload.id !== 'string' || typeof payload.accelerator !== 'string') {
+      return getShortcuts(store.getShortcutOverrides());
+    }
+    const cleanAccelerator = payload.accelerator.trim();
+    if (!cleanAccelerator) return getShortcuts(store.getShortcutOverrides());
+
+    store.setShortcutOverride(payload.id, cleanAccelerator);
+    const overrides = store.getShortcutOverrides();
+    applyOverrides(overrides);
+    if (actions.onShortcutsUpdated) {
+      actions.onShortcutsUpdated(overrides);
+    }
+    return getShortcuts(overrides);
+  });
+
+  ipcMain.handle('manager:resetShortcut', (e, id) => {
+    if (typeof id !== 'string') return getShortcuts(store.getShortcutOverrides());
+    store.clearShortcutOverride(id);
+    const overrides = store.getShortcutOverrides();
+    applyOverrides(overrides);
+    if (actions.onShortcutsUpdated) {
+      actions.onShortcutsUpdated(overrides);
+    }
+    return getShortcuts(overrides);
+  });
 
   // ---------- Workspaces (issue #8) ----------
   ipcMain.on('manager:setWorkspace', (e, id) => {

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -58,8 +58,24 @@ const GLOBAL_SHORTCUT = SHORTCUTS.find((shortcut) => shortcut.scope === 'global'
 
 const FALLBACK_BINDING = GLOBAL_SHORTCUT.accelerator;
 
+let activeOverrides = {};
+
+function resolveShortcuts(overrides = activeOverrides) {
+  return SHORTCUTS.map((shortcut) => {
+    const accelerator = overrides[shortcut.id] || shortcut.accelerator;
+    return {
+      ...shortcut,
+      accelerator,
+      defaultAccelerator: shortcut.accelerator,
+      isCustom: Boolean(overrides[shortcut.id] && overrides[shortcut.id] !== shortcut.accelerator)
+    };
+  });
+}
+
 // id -> accelerator, for callers that only need the string.
-const BINDINGS = Object.fromEntries(APP_SHORTCUTS.map((s) => [s.id, s.accelerator]));
+let BINDINGS = Object.fromEntries(
+  resolveShortcuts().filter((s) => s.scope === 'app').map((s) => [s.id, s.accelerator])
+);
 
 // The matcher keys off the final segment of the accelerator rather than a
 // field of its own, so the key the app listens for and the key the legend
@@ -69,13 +85,28 @@ function keyOf(accelerator) {
   return parts[parts.length - 1];
 }
 
-const ACTION_BY_KEY = Object.fromEntries(
-  APP_SHORTCUTS.map((s) => [keyOf(s.accelerator).toLowerCase(), s.id])
-);
+let ACTION_BY_KEY = {};
+let ACTION_BY_CODE = {};
 
-const ACTION_BY_CODE = Object.fromEntries(
-  APP_SHORTCUTS.map((s) => [`Key${keyOf(s.accelerator).toUpperCase()}`, s.id])
-);
+function buildLookupTables(overrides = activeOverrides) {
+  const appShortcuts = resolveShortcuts(overrides).filter((s) => s.scope === 'app');
+  ACTION_BY_KEY = Object.fromEntries(
+    appShortcuts.map((s) => [keyOf(s.accelerator).toLowerCase(), s.id])
+  );
+  ACTION_BY_CODE = Object.fromEntries(
+    appShortcuts.map((s) => [`Key${keyOf(s.accelerator).toUpperCase()}`, s.id])
+  );
+  BINDINGS = Object.fromEntries(
+    appShortcuts.map((s) => [s.id, s.accelerator])
+  );
+}
+
+buildLookupTables();
+
+function applyOverrides(overrides = {}) {
+  activeOverrides = { ...overrides };
+  buildLookupTables(activeOverrides);
+}
 
 // The list every UI reads from — the tray menu and the legend in the Notes
 // Manager — with a platform-formatted `display` string so no caller has to
@@ -85,8 +116,8 @@ const ACTION_BY_CODE = Object.fromEntries(
 // defaults. Keeping the definitions in one list, and deriving the matcher's
 // lookup tables from it instead of hand-maintaining a parallel copy, is what
 // makes that a change in one place rather than four.
-function getShortcuts() {
-  return SHORTCUTS.map((shortcut) => ({
+function getShortcuts(overrides = activeOverrides) {
+  return resolveShortcuts(overrides).map((shortcut) => ({
     ...shortcut,
     display: platform.formatAccelerator(shortcut.accelerator)
   }));
@@ -109,24 +140,28 @@ function registerShortcuts(win, actions) {
   });
 }
 
-function registerFallbackShortcut(globalShortcut, handler) {
-  const registered = globalShortcut.register(FALLBACK_BINDING, handler);
+function registerFallbackShortcut(globalShortcut, handler, customBinding) {
+  const binding = customBinding || activeOverrides[GLOBAL_SHORTCUT.id] || FALLBACK_BINDING;
+  const registered = globalShortcut.register(binding, handler);
   if (!registered) {
-    console.warn(`Fallback shortcut ${FALLBACK_BINDING} could not be registered — likely in use by another app.`);
+    console.warn(`Fallback shortcut ${binding} could not be registered — likely in use by another app.`);
   }
   return registered;
 }
 
-function unregisterFallbackShortcut(globalShortcut) {
-  globalShortcut.unregister(FALLBACK_BINDING);
+function unregisterFallbackShortcut(globalShortcut, customBinding) {
+  const binding = customBinding || activeOverrides[GLOBAL_SHORTCUT.id] || FALLBACK_BINDING;
+  globalShortcut.unregister(binding);
 }
 
 module.exports = {
+  SHORTCUTS,
   registerShortcuts,
   registerFallbackShortcut,
   unregisterFallbackShortcut,
   shortcutNameForInput,
   getShortcuts,
-  BINDINGS,
+  applyOverrides,
+  get BINDINGS() { return BINDINGS; },
   FALLBACK_BINDING
 };

--- a/store.js
+++ b/store.js
@@ -93,7 +93,7 @@ function emptyStore() {
   });
   return {
     version: STORE_VERSION,
-    settings: { activeWorkspace: workspace.id },
+    settings: { activeWorkspace: workspace.id, shortcuts: {} },
     workspaces: [workspace],
     notes: []
   };
@@ -410,6 +410,27 @@ class NoteStore {
 
   settings() {
     return this.data.settings;
+  }
+
+  // ---------- Shortcut Overrides (issue #5) ----------
+  getShortcutOverrides() {
+    return this.data.settings?.shortcuts || {};
+  }
+
+  setShortcutOverride(id, accelerator) {
+    if (!this.data.settings) this.data.settings = {};
+    if (!this.data.settings.shortcuts) this.data.settings.shortcuts = {};
+    this.data.settings.shortcuts[id] = accelerator;
+    this.save();
+    return this.data.settings.shortcuts;
+  }
+
+  clearShortcutOverride(id) {
+    if (this.data.settings?.shortcuts && id in this.data.settings.shortcuts) {
+      delete this.data.settings.shortcuts[id];
+      this.save();
+    }
+    return this.data.settings?.shortcuts || {};
   }
 
   workspaces() {

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -9,6 +9,7 @@ const {
   unregisterFallbackShortcut,
   shortcutNameForInput,
   getShortcuts,
+  applyOverrides,
   BINDINGS,
   FALLBACK_BINDING
 } = require('../shortcuts');
@@ -159,4 +160,31 @@ test('formats accelerators the way this platform writes them', () => {
     platform.isMac ? '⌘Q' : 'Ctrl+Q'
   );
   assert.equal(platform.formatAccelerator(''), '');
+});
+
+test('getShortcuts reflects custom overrides when provided', () => {
+  const overrides = { newNote: 'CommandOrControl+Shift+Q' };
+  const list = getShortcuts(overrides);
+  const newNote = list.find((s) => s.id === 'newNote');
+  assert.equal(newNote.accelerator, 'CommandOrControl+Shift+Q');
+  assert.equal(newNote.isCustom, true);
+  assert.equal(newNote.display, platform.formatAccelerator('CommandOrControl+Shift+Q'));
+
+  // Other shortcuts remain untouched
+  const managerShortcut = list.find((s) => s.id === 'openManager');
+  assert.equal(managerShortcut.accelerator, 'CommandOrControl+Shift+M');
+  assert.equal(managerShortcut.isCustom, false);
+});
+
+test('applyOverrides updates shortcut matcher tables dynamically', () => {
+  try {
+    applyOverrides({ newNote: 'CommandOrControl+Shift+Q' });
+    assert.equal(shortcutNameForInput(shortcutInput('Q')), 'newNote');
+    assert.equal(shortcutNameForInput(shortcutInput('N')), null);
+  } finally {
+    // Reset back to defaults
+    applyOverrides({});
+    assert.equal(shortcutNameForInput(shortcutInput('N')), 'newNote');
+    assert.equal(shortcutNameForInput(shortcutInput('Q')), null);
+  }
 });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -363,3 +363,24 @@ test('replaceAll replaces notes but preserves settings and workspaces', () => {
   assert.equal(store.getWorkspace(ws.id).name, 'Work');
   assert.equal(store.activeWorkspaceId(), DEFAULT_WORKSPACE_ID);
 });
+
+test('persists, updates and clears shortcut overrides in NoteStore', () => {
+  const dir = storeDir();
+  const store1 = openStore(dir);
+  assert.deepEqual(store1.getShortcutOverrides(), {});
+
+  store1.setShortcutOverride('newNote', 'CommandOrControl+Shift+X');
+  assert.equal(store1.getShortcutOverrides().newNote, 'CommandOrControl+Shift+X');
+  store1.flush();
+
+  // Reload from disk into a fresh instance
+  const store2 = openStore(dir);
+  assert.equal(store2.getShortcutOverrides().newNote, 'CommandOrControl+Shift+X');
+
+  store2.clearShortcutOverride('newNote');
+  assert.equal(store2.getShortcutOverrides().newNote, undefined);
+  store2.flush();
+
+  const store3 = openStore(dir);
+  assert.deepEqual(store3.getShortcutOverrides(), {});
+});


### PR DESCRIPTION
## Description

Allows users to customize global and app-scoped keyboard shortcuts directly from the Notes Manager shortcut legend. Key combinations can be recorded inline with a single click, stored in `NoteStore`, and hot-swapped dynamically without requiring an app restart. Users can also reset any customized shortcut back to its default binding.

## Related Issue

Closes #5

## Changes Made

- Saved custom overrides under `settings.shortcuts` in `notes.json` with getter, setter, and reset methods
- Added `resolveShortcuts()` and `applyOverrides()` to dynamically rebuild matcher lookup tables at runtime without restarting the app
- Synchronized fallback global shortcut re-registration and tray menu accelerators upon shortcut changes
- Added an Edit button per row to capture keystrokes, an active recording pulse state, and a Reset button to revert to default

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux (if applicable)

**Steps to reproduce / verify:**
1. Open the Notes Manager and click the **`?`** icon in the toolbar to open the **Keyboard Shortcuts** sheet.
2. Click the **(Edit)** icon next to any shortcut
3. The badge displays a pulsing `Press keys…` indicator. Press a new key combination (e.g., `Ctrl+Shift+P`).
4. Verify that the displayed badge updates to the new combination and a **Reset** button appears.
5. Press the new shortcut to verify it immediately triggers the action.
6. Click **Reset** and confirm the shortcut returns to its default binding (`Ctrl+Shift+N`).
7. Run `npm test` to verify all 38 test suites pass.

## Screenshots / Recordings (if applicable)
https://github.com/user-attachments/assets/50cc7eec-c825-4806-a839-22ab8cc2c907

## Checklist

- [x] I commented on the issue and was assigned before starting work
- [x] My branch is up to date with `develop`
- [x] My changes are focused this PR does one thing
- [x] I have not introduced any `console.log` statements I didn't intend to keep
- [x] Platform-specific logic (if any) is isolated inside `platform.js`